### PR TITLE
PR 2: Code quality — cleaner logic, robust config, test seam

### DIFF
--- a/src/main/java/online/slavok/heads/mixin/PlayerDeathMixin.java
+++ b/src/main/java/online/slavok/heads/mixin/PlayerDeathMixin.java
@@ -11,8 +11,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(ServerPlayerEntity.class)
 public class PlayerDeathMixin {
 	@Inject(at = @At("HEAD"), method = "onDeath")
-	private void onDeath(DamageSource damageSource, CallbackInfo info) {
-		var instance = ((ServerPlayerEntity)(Object)this);
-		new PlayerDeathEvent().onPlayerDeath(instance.getGameProfile(), instance.getInventory(), damageSource);
+	private void simplePlayerHeads$onDeath(DamageSource damageSource, CallbackInfo info) {
+		ServerPlayerEntity self = (ServerPlayerEntity) (Object) this;
+		PlayerDeathEvent.onPlayerDeath(self.getGameProfile(), self.getInventory(), damageSource);
 	}
 }

--- a/src/main/kotlin/online/slavok/heads/ModBehavior.kt
+++ b/src/main/kotlin/online/slavok/heads/ModBehavior.kt
@@ -1,0 +1,11 @@
+package online.slavok.heads
+
+/**
+ * Test seam for gametests. Production always leaves this `true`; a gametest flips it to `false`
+ * to assert the vanilla (no head) outcome as an A/B negative control, proving the head drop is
+ * caused by this mod's code rather than something incidental.
+ */
+object ModBehavior {
+    @JvmField
+    var active: Boolean = true
+}

--- a/src/main/kotlin/online/slavok/heads/SimplePlayerHeads.kt
+++ b/src/main/kotlin/online/slavok/heads/SimplePlayerHeads.kt
@@ -5,8 +5,11 @@ import net.fabricmc.loader.api.FabricLoader
 import online.slavok.heads.config.ConfigManager
 
 object SimplePlayerHeads : ModInitializer {
-	val configManager = ConfigManager(FabricLoader.getInstance().configDir.resolve("simple-player-heads.toml").toFile())
+    lateinit var configManager: ConfigManager
+        private set
 
-	override fun onInitialize() {
-	}
+    override fun onInitialize() {
+        val configFile = FabricLoader.getInstance().configDir.resolve("simple-player-heads.toml").toFile()
+        configManager = ConfigManager(configFile)
+    }
 }

--- a/src/main/kotlin/online/slavok/heads/config/ConfigManager.kt
+++ b/src/main/kotlin/online/slavok/heads/config/ConfigManager.kt
@@ -1,19 +1,48 @@
 package online.slavok.heads.config
 
 import net.peanuuutz.tomlkt.Toml
+import org.slf4j.LoggerFactory
 import java.io.File
 
-class ConfigManager (
-    configFile: File
-) {
+/**
+ * Loads and persists the mod config. On a missing or malformed file it falls back to defaults
+ * and (re)writes a valid file instead of crashing.
+ */
+class ConfigManager(private val configFile: File) {
     var config: Config = Config()
+        private set
 
     init {
-        if (!configFile.exists()) {
-            configFile.createNewFile()
-            configFile.writeText(Toml.encodeToString(Config.serializer(), config))
+        load()
+    }
+
+    private fun load() {
+        config = if (configFile.exists()) {
+            try {
+                Toml.decodeFromString(Config.serializer(), configFile.readText())
+            } catch (e: Exception) {
+                LOGGER.error("Failed to parse {}, using defaults", configFile.name, e)
+                Config()
+            }
         } else {
-            config = Toml.decodeFromString(Config.serializer(), configFile.readText())
+            Config()
         }
+        // Normalize the file: create it if missing, add any new fields with comments.
+        save()
+    }
+
+    /** Replaces the active config and persists it to disk. */
+    fun save(newConfig: Config = config) {
+        config = newConfig
+        try {
+            configFile.parentFile?.mkdirs()
+            configFile.writeText(Toml.encodeToString(Config.serializer(), config))
+        } catch (e: Exception) {
+            LOGGER.error("Failed to write {}", configFile.name, e)
+        }
+    }
+
+    private companion object {
+        val LOGGER: org.slf4j.Logger = LoggerFactory.getLogger("simple-player-heads")
     }
 }

--- a/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
+++ b/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
@@ -8,21 +8,25 @@ import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.entity.player.PlayerInventory
 import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
+import online.slavok.heads.ModBehavior
 import online.slavok.heads.SimplePlayerHeads
 
-class PlayerDeathEvent {
+object PlayerDeathEvent {
+    @JvmStatic
     fun onPlayerDeath(gameProfile: GameProfile, inventory: PlayerInventory, damageSource: DamageSource) {
-        val config = SimplePlayerHeads.configManager.config
-        if (damageSource.attacker is PlayerEntity) {
-            if ((damageSource.attacker as PlayerEntity).gameProfile == gameProfile) {
-                if (config.selfKill) {
-                    addHead(gameProfile, inventory)
-                }
-            } else if (config.playerKill) {
-                addHead(gameProfile, inventory)
-            }
-        } else if (config.otherDeaths) {
+        if (!ModBehavior.active) return
+        if (shouldDropHead(gameProfile, damageSource)) {
             addHead(gameProfile, inventory)
+        }
+    }
+
+    private fun shouldDropHead(gameProfile: GameProfile, damageSource: DamageSource): Boolean {
+        val config = SimplePlayerHeads.configManager.config
+        val attacker = damageSource.attacker
+        return when {
+            attacker is PlayerEntity && attacker.gameProfile == gameProfile -> config.selfKill
+            attacker is PlayerEntity -> config.playerKill
+            else -> config.otherDeaths
         }
     }
 


### PR DESCRIPTION
Stacked on #2 (PR 1). Merge after PR 1.

## What
- `PlayerDeathEvent` -> `object` (no allocation per death); extract `shouldDropHead` / `addHead`.
- `ConfigManager`: eager load in `onInitialize`; **falls back to defaults on malformed TOML** instead of crashing; adds `save()` to persist a replaced config (used by the config screen in a later PR).
- `ModBehavior.active` test seam — lets gametests run an A/B negative control (mixin ON vs OFF) so a green test proves *our* code caused the head drop.
- Mixin now calls the object and uses a prefixed handler name to avoid mixin collisions.

## Risk
Behavior is **unchanged** for `ModBehavior.active == true` (always true in production). Pure refactor + hardening.

## Test
`./gradlew build` green (JDK 22 / Gradle 8.8). Full gametests arrive in PR 6.