### PR TITLE
PR 4: Yarn-era multiversion (1.18.2 -> 1.21.8)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,12 +18,16 @@ data class Mc(
 
 val mcVersion = stonecutter.current.version
 val mc = when (mcVersion) {
+    "1.18.2" -> Mc("1.18.2+build.4", 17, ">=1.18.2 <1.19", listOf("1.18.2"), "0.77.0+1.18.2")
+    "1.19.2" -> Mc("1.19.2+build.28", 17, ">=1.19 <1.19.3", listOf("1.19", "1.19.1", "1.19.2"), "0.77.0+1.19.2")
+    "1.19.4" -> Mc("1.19.4+build.2", 17, ">=1.19.3 <1.20", listOf("1.19.3", "1.19.4"), "0.87.2+1.19.4")
+    "1.20.1" -> Mc("1.20.1+build.10", 17, ">=1.20 <1.20.2", listOf("1.20", "1.20.1"), "0.92.11+1.20.1")
+    "1.20.4" -> Mc("1.20.4+build.3", 17, ">=1.20.2 <1.20.5", listOf("1.20.2", "1.20.3", "1.20.4"), "0.97.3+1.20.4")
+    "1.20.6" -> Mc("1.20.6+build.3", 21, ">=1.20.5 <1.21", listOf("1.20.5", "1.20.6"), "0.100.8+1.20.6")
     "1.21.8" -> Mc(
-        yarn = "1.21.8+build.1",
-        java = 21,
-        depends = ">=1.21 <1.22",
-        gameVersions = listOf("1.21", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8"),
-        fapi = "0.136.1+1.21.8",
+        "1.21.8+build.1", 21, ">=1.21 <1.22",
+        listOf("1.21", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8"),
+        "0.136.1+1.21.8",
     )
     else -> error("Unconfigured Minecraft version: $mcVersion")
 }
@@ -56,6 +60,9 @@ tasks.processResources {
     filesMatching(listOf("fabric.mod.json", "*.mixins.json")) { expand(props) }
 }
 
+// Cross-compile the per-version Java level (17 for <=1.20.4, 21 for 1.20.5+) from a
+// single JDK 21 build. Gametests, which must *run* on the matching JDK, switch this to
+// per-version toolchains in a later PR.
 tasks.withType<JavaCompile>().configureEach { options.release = mc.java }
 
 kotlin {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ stonecutter {
     kotlinController = true
     centralScript = "build.gradle.kts"
     create(rootProject) {
-        versions("1.21.8")
+        versions("1.18.2", "1.19.2", "1.19.4", "1.20.1", "1.20.4", "1.20.6", "1.21.8")
         vcsVersion = "1.21.8"
     }
 }

--- a/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
+++ b/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
@@ -1,8 +1,6 @@
 package online.slavok.heads.events
 
 import com.mojang.authlib.GameProfile
-import net.minecraft.component.DataComponentTypes
-import net.minecraft.component.type.ProfileComponent
 import net.minecraft.entity.damage.DamageSource
 import net.minecraft.entity.player.PlayerEntity
 import net.minecraft.entity.player.PlayerInventory
@@ -10,6 +8,13 @@ import net.minecraft.item.ItemStack
 import net.minecraft.item.Items
 import online.slavok.heads.ModBehavior
 import online.slavok.heads.SimplePlayerHeads
+//? if <1.20.5 {
+/*import net.minecraft.nbt.NbtCompound
+import net.minecraft.nbt.NbtHelper
+*///?} else {
+import net.minecraft.component.DataComponentTypes
+import net.minecraft.component.type.ProfileComponent
+//?}
 
 object PlayerDeathEvent {
     @JvmStatic
@@ -32,7 +37,12 @@ object PlayerDeathEvent {
 
     private fun addHead(gameProfile: GameProfile, inventory: PlayerInventory) {
         val head: ItemStack = Items.PLAYER_HEAD.defaultStack
+        //? if <1.20.5 {
+        /*val skullOwner = NbtHelper.writeGameProfile(NbtCompound(), gameProfile)
+        head.orCreateNbt.put("SkullOwner", skullOwner)
+        *///?} else {
         head.set(DataComponentTypes.PROFILE, ProfileComponent(gameProfile))
+        //?}
         inventory.insertStack(head)
     }
 }


### PR DESCRIPTION
Stacked on #4 (PR 3). Merge after PR 3.

Adds **7 build anchors** across the yarn-mapped range, all from one shared `src/`.

## What
- `settings.gradle.kts`: declare 1.18.2, 1.19.2, 1.19.4, 1.20.1, 1.20.4, 1.20.6, 1.21.8.
- `build.gradle.kts`: per-version `Mc` matrix — yarn mappings, Java level, `depends` range, **non-overlapping** Modrinth `gameVersions`, Fabric API. Cross-compiles the per-version Java level (17 for <=1.20.4, 21 for 1.20.5+) from a single JDK 21 build via `options.release`.
- `PlayerDeathEvent`: **Stonecutter source branch** for the head item — NBT `SkullOwner` (`<1.20.5`) vs `DataComponentTypes.PROFILE` (`>=1.20.5`). Everything else is yarn-stable across the range.

## Risk
Source branching is the only logic change; each era compiles only its own head API. No CI change (the existing `./gradlew build` now builds all 7).

## Test
`./gradlew build` green locally for all 7 anchors (JDK 21). The two mutually-exclusive head APIs each compile **only** in their era — proof the branch switches correctly. Metadata expands per version (1.18.2 -> `>=1.18.2 <1.19` / JAVA_17; 1.20.6 -> `>=1.20.5 <1.21` / JAVA_21).