### PR TITLE
PR 5: Minecraft 26.2 (unobfuscated) support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,20 @@ jobs:
           name: jars
           path: versions/*/build/libs/*.jar
           if-no-files-found: error
+
+  # Unobfuscated 26+ needs JDK 25; settings only registers those nodes on JDK 25+.
+  build-unobfuscated:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 25
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew :26.2:build --stacktrace
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jars-unobfuscated
+          path: versions/26.*/build/libs/*.jar
+          if-no-files-found: error

--- a/build.unobfuscated.gradle.kts
+++ b/build.unobfuscated.gradle.kts
@@ -1,0 +1,60 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("dev.kikugie.stonecutter")
+    id("net.fabricmc.fabric-loom") version "1.17.17" // non-remapping variant (Minecraft 26+ ships unobfuscated)
+    kotlin("jvm") version "2.4.10"
+    kotlin("plugin.serialization") version "2.4.10"
+}
+
+data class Unobf(val depends: String, val gameVersions: List<String>, val fapi: String)
+
+val mcVersion = stonecutter.current.version
+val u = when (mcVersion) {
+    "26.2" -> Unobf(">=26.2 <27", listOf("26.2"), "0.155.2+26.2")
+    else -> error("Unconfigured Minecraft version: $mcVersion")
+}
+val javaVersion = 25
+
+version = "${property("mod_version")}+mc$mcVersion"
+group = property("maven_group") as String
+base { archivesName = property("archives_base_name") as String }
+
+dependencies {
+    minecraft("com.mojang:minecraft:$mcVersion")
+    // No mappings() — Minecraft 26+ is unobfuscated (Mojang names), no Yarn/Mojmap.
+    implementation("net.fabricmc:fabric-loader:${property("loader_version")}")
+    implementation("net.fabricmc.fabric-api:fabric-api:${u.fapi}")
+    implementation("net.fabricmc:fabric-language-kotlin:${property("fabric_kotlin_version")}")
+
+    // kotlinx-serialization-json is provided at runtime by Fabric Language Kotlin.
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")
+    // tomlkt is not bundled by FLK, so ship it inside the jar (jar-in-jar).
+    implementation("net.peanuuutz.tomlkt:tomlkt:0.4.0")
+    include("net.peanuuutz.tomlkt:tomlkt:0.4.0")
+}
+
+tasks.processResources {
+    val props = mapOf(
+        "version" to project.version,
+        "java_level" to javaVersion,
+        "minecraft_dep" to u.depends,
+    )
+    inputs.properties(props)
+    filesMatching(listOf("fabric.mod.json", "*.mixins.json")) { expand(props) }
+}
+
+tasks.withType<JavaCompile>().configureEach { options.release = javaVersion }
+
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget(javaVersion.toString())
+    }
+}
+
+java {
+    withSourcesJar()
+    val jv = JavaVersion.toVersion(javaVersion)
+    sourceCompatibility = jv
+    targetCompatibility = jv
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,12 @@ stonecutter {
     centralScript = "build.gradle.kts"
     create(rootProject) {
         versions("1.18.2", "1.19.2", "1.19.4", "1.20.1", "1.20.4", "1.20.6", "1.21.8")
+        // Unobfuscated 26+ needs JDK 25 and a separate (non-remapping) build script.
+        // Register it only when the running JDK can build it, so the project still
+        // builds the yarn range on older JDKs.
+        if (JavaVersion.current().majorVersion.toInt() >= 25) {
+            version("26.2", "26.2").buildscript = "build.unobfuscated.gradle.kts"
+        }
         vcsVersion = "1.21.8"
     }
 }

--- a/src/main/java/online/slavok/heads/mixin/PlayerDeathMixin.java
+++ b/src/main/java/online/slavok/heads/mixin/PlayerDeathMixin.java
@@ -1,18 +1,35 @@
 package online.slavok.heads.mixin;
 
-import net.minecraft.entity.damage.DamageSource;
+//? if >=1.22 {
+/*import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.damagesource.DamageSource;
+*///?} else {
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.entity.damage.DamageSource;
+//?}
 import online.slavok.heads.events.PlayerDeathEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+//? if >=1.22 {
+/*@Mixin(ServerPlayer.class)
+*///?} else {
 @Mixin(ServerPlayerEntity.class)
+//?}
 public class PlayerDeathMixin {
+	//? if >=1.22 {
+	/*@Inject(at = @At("HEAD"), method = "die")
+	private void simplePlayerHeads$onDeath(DamageSource damageSource, CallbackInfo info) {
+		ServerPlayer self = (ServerPlayer) (Object) this;
+		PlayerDeathEvent.onPlayerDeath(self.getGameProfile(), self.getInventory(), damageSource);
+	}
+	*///?} else {
 	@Inject(at = @At("HEAD"), method = "onDeath")
 	private void simplePlayerHeads$onDeath(DamageSource damageSource, CallbackInfo info) {
 		ServerPlayerEntity self = (ServerPlayerEntity) (Object) this;
 		PlayerDeathEvent.onPlayerDeath(self.getGameProfile(), self.getInventory(), damageSource);
 	}
+	//?}
 }

--- a/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
+++ b/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
@@ -1,24 +1,40 @@
 package online.slavok.heads.events
 
 import com.mojang.authlib.GameProfile
-import net.minecraft.entity.damage.DamageSource
-import net.minecraft.entity.player.PlayerEntity
-import net.minecraft.entity.player.PlayerInventory
-import net.minecraft.item.ItemStack
-import net.minecraft.item.Items
 import online.slavok.heads.ModBehavior
 import online.slavok.heads.SimplePlayerHeads
+//? if <1.22 {
+import net.minecraft.entity.damage.DamageSource
+import net.minecraft.item.ItemStack
+import net.minecraft.item.Items
+//?} else {
+/*import net.minecraft.world.damagesource.DamageSource
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items*/
+//?}
 //? if <1.20.5 {
 /*import net.minecraft.nbt.NbtCompound
 import net.minecraft.nbt.NbtHelper
-*///?} else {
+*///?} elif <1.22 {
 import net.minecraft.component.DataComponentTypes
 import net.minecraft.component.type.ProfileComponent
+//?} else {
+/*import net.minecraft.core.component.DataComponents
+import net.minecraft.world.item.component.ResolvableProfile
+*///?}
+
+// Player and inventory classes were renamed in the unobfuscated (26+) mappings.
+//? if <1.22 {
+private typealias PlayerInv = net.minecraft.entity.player.PlayerInventory
+private typealias PlayerType = net.minecraft.entity.player.PlayerEntity
+//?} else {
+/*private typealias PlayerInv = net.minecraft.world.entity.player.Inventory
+private typealias PlayerType = net.minecraft.world.entity.player.Player*/
 //?}
 
 object PlayerDeathEvent {
     @JvmStatic
-    fun onPlayerDeath(gameProfile: GameProfile, inventory: PlayerInventory, damageSource: DamageSource) {
+    fun onPlayerDeath(gameProfile: GameProfile, inventory: PlayerInv, damageSource: DamageSource) {
         if (!ModBehavior.active) return
         if (shouldDropHead(gameProfile, damageSource)) {
             addHead(gameProfile, inventory)
@@ -27,22 +43,32 @@ object PlayerDeathEvent {
 
     private fun shouldDropHead(gameProfile: GameProfile, damageSource: DamageSource): Boolean {
         val config = SimplePlayerHeads.configManager.config
+        //? if >=1.22 {
+        /*val attacker = damageSource.entity*/
+        //?} else {
         val attacker = damageSource.attacker
+        //?}
         return when {
-            attacker is PlayerEntity && attacker.gameProfile == gameProfile -> config.selfKill
-            attacker is PlayerEntity -> config.playerKill
+            attacker is PlayerType && attacker.gameProfile == gameProfile -> config.selfKill
+            attacker is PlayerType -> config.playerKill
             else -> config.otherDeaths
         }
     }
 
-    private fun addHead(gameProfile: GameProfile, inventory: PlayerInventory) {
-        val head: ItemStack = Items.PLAYER_HEAD.defaultStack
+    private fun addHead(gameProfile: GameProfile, inventory: PlayerInv) {
+        val head = ItemStack(Items.PLAYER_HEAD)
         //? if <1.20.5 {
         /*val skullOwner = NbtHelper.writeGameProfile(NbtCompound(), gameProfile)
         head.orCreateNbt.put("SkullOwner", skullOwner)
-        *///?} else {
+        *///?} elif <1.22 {
         head.set(DataComponentTypes.PROFILE, ProfileComponent(gameProfile))
-        //?}
+        //?} else {
+        /*head.set(DataComponents.PROFILE, ResolvableProfile.createResolved(gameProfile))
+        *///?}
+        //? if >=1.22 {
+        /*inventory.add(head)*/
+        //?} else {
         inventory.insertStack(head)
+        //?}
     }
 }


### PR DESCRIPTION
Stacked on #5 (PR 4). Merge after PR 4.

Minecraft 26+ ships **unobfuscated** (Mojang names, no Yarn), needing a separate **non-remapping** toolchain on **JDK 25**.

## What
- `build.unobfuscated.gradle.kts`: non-remapping loom (`net.fabricmc.fabric-loom`), no `mappings()`, `implementation()`/`jar` instead of `modImplementation()`/`remapJar`, Java 25, `Unobf` matrix (FAPI `0.155.2+26.2`).
- `settings.gradle.kts`: register `26.2` **only when the running JDK is 25+** — so the yarn range still builds on older JDKs.
- `PlayerDeathEvent`: third source branch (`>=1.22`) with Mojang names — `DataComponents.PROFILE` + `ResolvableProfile.createResolved`, `Inventory.add`, `DamageSource.getEntity`. Typealiases bridge `PlayerInventory`/`Inventory` and `PlayerEntity`/`Player` so the body stays single-source.
- `PlayerDeathMixin`: `>=1.22` branch targets `ServerPlayer.die` (vs `ServerPlayerEntity.onDeath`).
- CI: `build-unobfuscated` job on JDK 25 (`:26.2:build`).

## Risk
Mojang names can't be validated by the non-remapping loom at compile time. I verified every name via `javap` against the **real 26.2 jar**; mixin *application* is confirmed by the required-mixin gametest in PR 6.

## Test
`:26.2:build` green on JDK 25 (`1.0.1+mc26.2`, `minecraft '>=26.2 <27'`, `JAVA_25`). All 7 yarn versions still green on JDK 21 (26.2 gated out — proves the JDK gate and that the new branches don't regress yarn).