### PR TITLE
PR 6: Gametests across all versions + PR gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Yarn-mapped versions build on JDK 21 (cross-compiles 17 via `options.release`).
-  # A plain `./gradlew build` builds every declared Stonecutter version.
+  # Yarn-mapped versions. JDK 17 and 21 are both installed so each version's
+  # gametest runs on the JDK that Minecraft version requires (per-version toolchains).
+  # A plain `./gradlew build` builds every declared version and runs its gametests.
   build:
     runs-on: ubuntu-latest
     steps:
@@ -19,7 +20,9 @@ jobs:
       - uses: gradle/actions/wrapper-validation@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: |
+            17
+            21
           distribution: temurin
       - uses: gradle/actions/setup-gradle@v4
       - run: ./gradlew build --stacktrace

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     id("dev.kikugie.stonecutter")
     id("fabric-loom") version "1.17.17"
@@ -50,6 +48,18 @@ dependencies {
     include("net.peanuuutz.tomlkt:tomlkt:0.4.0")
 }
 
+fabricApi {
+    configureTests {
+        createSourceSet = true
+        modId = "${property("archives_base_name")}-test"
+        eula = true
+    }
+}
+
+dependencies {
+    "modGametestImplementation"("net.fabricmc.fabric-api:fabric-api:${mc.fapi}")
+}
+
 tasks.processResources {
     val props = mapOf(
         "version" to project.version,
@@ -60,20 +70,13 @@ tasks.processResources {
     filesMatching(listOf("fabric.mod.json", "*.mixins.json")) { expand(props) }
 }
 
-// Cross-compile the per-version Java level (17 for <=1.20.4, 21 for 1.20.5+) from a
-// single JDK 21 build. Gametests, which must *run* on the matching JDK, switch this to
-// per-version toolchains in a later PR.
-tasks.withType<JavaCompile>().configureEach { options.release = mc.java }
-
-kotlin {
-    compilerOptions {
-        jvmTarget = JvmTarget.fromTarget(mc.java.toString())
-    }
+// One JDK toolchain per Minecraft version (17 for <=1.20.4, 21 for 1.20.5+) so both
+// compilation and gametests run on the JDK that Minecraft version requires.
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(mc.java)
+    withSourcesJar()
 }
 
-java {
-    withSourcesJar()
-    val jv = JavaVersion.toVersion(mc.java)
-    sourceCompatibility = jv
-    targetCompatibility = jv
+kotlin {
+    jvmToolchain(mc.java)
 }

--- a/build.unobfuscated.gradle.kts
+++ b/build.unobfuscated.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
     id("dev.kikugie.stonecutter")
     id("net.fabricmc.fabric-loom") version "1.17.17" // non-remapping variant (Minecraft 26+ ships unobfuscated)
@@ -34,6 +32,19 @@ dependencies {
     include("net.peanuuutz.tomlkt:tomlkt:0.4.0")
 }
 
+fabricApi {
+    configureTests {
+        createSourceSet = true
+        modId = "${property("archives_base_name")}-test"
+        eula = true
+    }
+}
+
+dependencies {
+    // Non-remapping variant: no "mod" prefix, no remap.
+    "gametestImplementation"("net.fabricmc.fabric-api:fabric-api:${u.fapi}")
+}
+
 tasks.processResources {
     val props = mapOf(
         "version" to project.version,
@@ -44,17 +55,11 @@ tasks.processResources {
     filesMatching(listOf("fabric.mod.json", "*.mixins.json")) { expand(props) }
 }
 
-tasks.withType<JavaCompile>().configureEach { options.release = javaVersion }
-
-kotlin {
-    compilerOptions {
-        jvmTarget = JvmTarget.fromTarget(javaVersion.toString())
-    }
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(javaVersion)
+    withSourcesJar()
 }
 
-java {
-    withSourcesJar()
-    val jv = JavaVersion.toVersion(javaVersion)
-    sourceCompatibility = jv
-    targetCompatibility = jv
+kotlin {
+    jvmToolchain(javaVersion)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,9 @@
 # Done to increase the memory available to gradle.
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
+# Discover the JDKs that GitHub's setup-java exports, so gametests run on the
+# JDK each Minecraft version needs (17 / 21 / 25). Harmless locally.
+org.gradle.java.installations.fromEnv=JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64
 
 # Mod Properties
 mod_version=1.0.1

--- a/src/gametest/java/online/slavok/heads/gametest/HeadDropGameTest.java
+++ b/src/gametest/java/online/slavok/heads/gametest/HeadDropGameTest.java
@@ -1,0 +1,77 @@
+package online.slavok.heads.gametest;
+
+import com.mojang.authlib.GameProfile;
+import online.slavok.heads.events.PlayerDeathEvent;
+
+import java.util.UUID;
+
+//? if >=1.21 {
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+//?} else {
+/*import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.test.GameTest;*/
+//?}
+//? if >=1.22 {
+/*import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.core.component.DataComponents;*/
+//?} else {
+import net.minecraft.test.TestContext;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+//?}
+//? if >=1.20.5 && <1.22 {
+import net.minecraft.component.DataComponentTypes;
+//?}
+
+/**
+ * Verifies that the version-specific head creation actually produces a profile-bearing
+ * player head at runtime, on every supported Minecraft version. This is an A/B test: the
+ * created head must carry the profile, while a plain player head must not — proving our
+ * code (not the item itself) attaches the profile. Booting the gametest server also loads
+ * the mixin target class; with a required mixin, a wrong target would crash on load.
+ */
+//? if >=1.21 {
+public class HeadDropGameTest {
+//?} else {
+/*public class HeadDropGameTest implements FabricGameTest {*/
+//?}
+
+    //? if >=1.21 {
+    @GameTest
+    //?} elif >=1.19 {
+    /*@GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)*/
+    //?} else {
+    /*@GameTest(structureName = FabricGameTest.EMPTY_STRUCTURE)*/
+    //?}
+    //? if >=1.22 {
+    /*public void createdHeadCarriesProfile(GameTestHelper context) {
+        GameProfile profile = new GameProfile(UUID.randomUUID(), "TestVictim");
+        ItemStack head = PlayerDeathEvent.createHead(profile);
+        if (head.getItem() != Items.PLAYER_HEAD) throw new RuntimeException("created item is not a player head");
+        if (!hasProfile(head)) throw new RuntimeException("created head is missing its profile");
+        if (hasProfile(new ItemStack(Items.PLAYER_HEAD))) throw new RuntimeException("control failed: a plain head has a profile");
+        context.succeed();
+    }*/
+    //?} else {
+    public void createdHeadCarriesProfile(TestContext context) {
+        GameProfile profile = new GameProfile(UUID.randomUUID(), "TestVictim");
+        ItemStack head = PlayerDeathEvent.createHead(profile);
+        if (head.getItem() != Items.PLAYER_HEAD) throw new RuntimeException("created item is not a player head");
+        if (!hasProfile(head)) throw new RuntimeException("created head is missing its profile");
+        if (hasProfile(new ItemStack(Items.PLAYER_HEAD))) throw new RuntimeException("control failed: a plain head has a profile");
+        context.complete();
+    }
+    //?}
+
+    private static boolean hasProfile(ItemStack head) {
+        //? if <1.20.5 {
+        /*return head.getNbt() != null && head.getNbt().contains("SkullOwner");*/
+        //?} elif <1.22 {
+        return head.get(DataComponentTypes.PROFILE) != null;
+        //?} else {
+        /*return head.get(DataComponents.PROFILE) != null;*/
+        //?}
+    }
+}

--- a/src/gametest/resources/fabric.mod.json
+++ b/src/gametest/resources/fabric.mod.json
@@ -1,0 +1,16 @@
+{
+	"schemaVersion": 1,
+	"id": "simple-player-heads-test",
+	"version": "1.0.0",
+	"name": "Simple Player Heads Test",
+	"environment": "*",
+	"entrypoints": {
+		"fabric-gametest": [
+			"online.slavok.heads.gametest.HeadDropGameTest"
+		]
+	},
+	"depends": {
+		"simple-player-heads": "*",
+		"fabric-gametest-api-v1": "*"
+	}
+}

--- a/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
+++ b/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
@@ -56,6 +56,17 @@ object PlayerDeathEvent {
     }
 
     private fun addHead(gameProfile: GameProfile, inventory: PlayerInv) {
+        val head = createHead(gameProfile)
+        //? if >=1.22 {
+        /*inventory.add(head)*/
+        //?} else {
+        inventory.insertStack(head)
+        //?}
+    }
+
+    /** Builds a player head carrying [gameProfile]. Public so gametests can verify it per version. */
+    @JvmStatic
+    fun createHead(gameProfile: GameProfile): ItemStack {
         val head = ItemStack(Items.PLAYER_HEAD)
         //? if <1.20.5 {
         /*val skullOwner = NbtHelper.writeGameProfile(NbtCompound(), gameProfile)
@@ -65,10 +76,6 @@ object PlayerDeathEvent {
         //?} else {
         /*head.set(DataComponents.PROFILE, ResolvableProfile.createResolved(gameProfile))
         *///?}
-        //? if >=1.22 {
-        /*inventory.add(head)*/
-        //?} else {
-        inventory.insertStack(head)
-        //?}
+        return head
     }
 }


### PR DESCRIPTION
Stacked on #6 (PR 5). Merge after PR 5. Delivers goal #2 (tests on every version) and the gametest-on-PR half of goal #3.

## What
- `fabricApi.configureTests` in both build scripts; per-version Fabric API on the gametest source set.
- `src/gametest/HeadDropGameTest`: an **A/B control** — the created head must carry the profile while a **plain** player head must not, proving *our* code attaches it. Booting the test server also loads the mixin target class (required mixin => a wrong target crashes on load). Stonecutter-branched across all four GameTest API eras (1.18 `structureName` / 1.19-1.20 `templateName` / 1.21+ v1 / 26+ `GameTestHelper`) and the three head read-back eras.
- `PlayerDeathEvent.createHead` extracted as the testable per-version seam.
- **Per-version JDK toolchains** so each gametest runs on the JDK its Minecraft version needs; `org.gradle.java.installations.fromEnv` discovers CI-provided JDKs.
- CI: yarn job installs JDK 17 + 21 and runs all yarn gametests via `check`; unobfuscated job runs the 26.2 gametest on JDK 25.

## Test
Gametests **green on all 8 versions** locally (1.18.2, 1.19.2, 1.19.4, 1.20.1, 1.20.4, 1.20.6, 1.21.8, 26.2). **Negative control verified**: disabling the profile-set makes the 1.21.8 test fail with `created head is missing its profile` — so the test can actually fail.