### PR TITLE
PR 7: Simple ModMenu config screen (Cloth Config)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ otherDeaths = true
 - `playerKill`: If true, player will get his head after kill by another player
 - `otherDeaths`: If true, player will get his head after all other deaths
 
+You can also edit these options in-game from the [Mod Menu](https://modrinth.com/mod/modmenu) config screen (Cloth Config is bundled).
+
 
 ## Installation
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,26 +6,29 @@ plugins {
 }
 
 // Per-version matrix. `fapi` (Fabric API) is used by the main mod and the gametest source set.
+// `cloth` / `modmenu` power the optional in-game config screen.
 data class Mc(
     val yarn: String,
     val java: Int,
     val depends: String,
     val gameVersions: List<String>,
     val fapi: String,
+    val cloth: String,
+    val modmenu: String,
 )
 
 val mcVersion = stonecutter.current.version
 val mc = when (mcVersion) {
-    "1.18.2" -> Mc("1.18.2+build.4", 17, ">=1.18.2 <1.19", listOf("1.18.2"), "0.77.0+1.18.2")
-    "1.19.2" -> Mc("1.19.2+build.28", 17, ">=1.19 <1.19.3", listOf("1.19", "1.19.1", "1.19.2"), "0.77.0+1.19.2")
-    "1.19.4" -> Mc("1.19.4+build.2", 17, ">=1.19.3 <1.20", listOf("1.19.3", "1.19.4"), "0.87.2+1.19.4")
-    "1.20.1" -> Mc("1.20.1+build.10", 17, ">=1.20 <1.20.2", listOf("1.20", "1.20.1"), "0.92.11+1.20.1")
-    "1.20.4" -> Mc("1.20.4+build.3", 17, ">=1.20.2 <1.20.5", listOf("1.20.2", "1.20.3", "1.20.4"), "0.97.3+1.20.4")
-    "1.20.6" -> Mc("1.20.6+build.3", 21, ">=1.20.5 <1.21", listOf("1.20.5", "1.20.6"), "0.100.8+1.20.6")
+    "1.18.2" -> Mc("1.18.2+build.4", 17, ">=1.18.2 <1.19", listOf("1.18.2"), "0.77.0+1.18.2", "6.5.102", "3.2.5")
+    "1.19.2" -> Mc("1.19.2+build.28", 17, ">=1.19 <1.19.3", listOf("1.19", "1.19.1", "1.19.2"), "0.77.0+1.19.2", "8.3.134", "4.1.2")
+    "1.19.4" -> Mc("1.19.4+build.2", 17, ">=1.19.3 <1.20", listOf("1.19.3", "1.19.4"), "0.87.2+1.19.4", "10.1.135", "6.3.1")
+    "1.20.1" -> Mc("1.20.1+build.10", 17, ">=1.20 <1.20.2", listOf("1.20", "1.20.1"), "0.92.11+1.20.1", "11.1.136", "7.2.2")
+    "1.20.4" -> Mc("1.20.4+build.3", 17, ">=1.20.2 <1.20.5", listOf("1.20.2", "1.20.3", "1.20.4"), "0.97.3+1.20.4", "13.0.138", "9.2.0")
+    "1.20.6" -> Mc("1.20.6+build.3", 21, ">=1.20.5 <1.21", listOf("1.20.5", "1.20.6"), "0.100.8+1.20.6", "14.0.139", "10.0.0")
     "1.21.8" -> Mc(
         "1.21.8+build.1", 21, ">=1.21 <1.22",
         listOf("1.21", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8"),
-        "0.136.1+1.21.8",
+        "0.136.1+1.21.8", "19.0.147", "15.0.2",
     )
     else -> error("Unconfigured Minecraft version: $mcVersion")
 }
@@ -34,12 +37,26 @@ version = "${property("mod_version")}+mc$mcVersion"
 group = property("maven_group") as String
 base { archivesName = property("archives_base_name") as String }
 
+repositories {
+    maven("https://maven.terraformersmc.com/releases/") // ModMenu
+    maven("https://maven.shedaniel.me/")                 // Cloth Config
+    maven("https://maven.nucleoid.xyz/")                 // placeholder-api (transitive of older ModMenu)
+}
+
 dependencies {
     minecraft("com.mojang:minecraft:$mcVersion")
     mappings("net.fabricmc:yarn:${mc.yarn}:v2")
     modImplementation("net.fabricmc:fabric-loader:${property("loader_version")}")
     modImplementation("net.fabricmc.fabric-api:fabric-api:${mc.fapi}")
     modImplementation("net.fabricmc:fabric-language-kotlin:${property("fabric_kotlin_version")}")
+
+    // Config screen: ModMenu is optional (a "suggests"), so compile-only. Cloth Config
+    // is bundled (jar-in-jar) so the screen works without the user installing it.
+    modImplementation("com.terraformersmc:modmenu:${mc.modmenu}")
+    modImplementation("me.shedaniel.cloth:cloth-config-fabric:${mc.cloth}") {
+        exclude(group = "net.fabricmc.fabric-api")
+    }
+    include("me.shedaniel.cloth:cloth-config-fabric:${mc.cloth}")
 
     // kotlinx-serialization-json is provided at runtime by Fabric Language Kotlin.
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")

--- a/build.unobfuscated.gradle.kts
+++ b/build.unobfuscated.gradle.kts
@@ -5,11 +5,11 @@ plugins {
     kotlin("plugin.serialization") version "2.4.10"
 }
 
-data class Unobf(val depends: String, val gameVersions: List<String>, val fapi: String)
+data class Unobf(val depends: String, val gameVersions: List<String>, val fapi: String, val cloth: String, val modmenu: String)
 
 val mcVersion = stonecutter.current.version
 val u = when (mcVersion) {
-    "26.2" -> Unobf(">=26.2 <27", listOf("26.2"), "0.155.2+26.2")
+    "26.2" -> Unobf(">=26.2 <27", listOf("26.2"), "0.155.2+26.2", "26.2.155", "20.0.1")
     else -> error("Unconfigured Minecraft version: $mcVersion")
 }
 val javaVersion = 25
@@ -18,12 +18,25 @@ version = "${property("mod_version")}+mc$mcVersion"
 group = property("maven_group") as String
 base { archivesName = property("archives_base_name") as String }
 
+repositories {
+    maven("https://maven.terraformersmc.com/releases/") // ModMenu
+    maven("https://maven.shedaniel.me/")                 // Cloth Config
+    maven("https://maven.nucleoid.xyz/")                 // placeholder-api (transitive of older ModMenu)
+}
+
 dependencies {
     minecraft("com.mojang:minecraft:$mcVersion")
     // No mappings() — Minecraft 26+ is unobfuscated (Mojang names), no Yarn/Mojmap.
     implementation("net.fabricmc:fabric-loader:${property("loader_version")}")
     implementation("net.fabricmc.fabric-api:fabric-api:${u.fapi}")
     implementation("net.fabricmc:fabric-language-kotlin:${property("fabric_kotlin_version")}")
+
+    // Config screen: ModMenu optional (compile-only); Cloth Config bundled (jar-in-jar).
+    implementation("com.terraformersmc:modmenu:${u.modmenu}")
+    implementation("me.shedaniel.cloth:cloth-config-fabric:${u.cloth}") {
+        exclude(group = "net.fabricmc.fabric-api")
+    }
+    include("me.shedaniel.cloth:cloth-config-fabric:${u.cloth}")
 
     // kotlinx-serialization-json is provided at runtime by Fabric Language Kotlin.
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")

--- a/src/main/kotlin/online/slavok/heads/ModMenuIntegration.kt
+++ b/src/main/kotlin/online/slavok/heads/ModMenuIntegration.kt
@@ -1,0 +1,65 @@
+package online.slavok.heads
+
+import com.terraformersmc.modmenu.api.ConfigScreenFactory
+import com.terraformersmc.modmenu.api.ModMenuApi
+import me.shedaniel.clothconfig2.api.ConfigBuilder
+import online.slavok.heads.config.Config
+//? if >=1.22 {
+/*import net.minecraft.network.chat.Component
+*///?} else {
+import net.minecraft.text.Text
+//?}
+//? if <1.19 {
+/*import net.minecraft.text.LiteralText*/
+//?}
+
+/**
+ * A tiny Cloth Config screen exposed through ModMenu. ModMenu is optional; when it is
+ * absent this entrypoint is simply never called and the config stays file-only.
+ */
+class ModMenuIntegration : ModMenuApi {
+    override fun getModConfigScreenFactory(): ConfigScreenFactory<*> = ConfigScreenFactory { parent ->
+        val config = SimplePlayerHeads.configManager.config
+        val builder = ConfigBuilder.create()
+            .setParentScreen(parent)
+            .setTitle(literal("Simple Player Heads"))
+        val category = builder.getOrCreateCategory(literal("General"))
+        val entries = builder.entryBuilder()
+
+        var selfKill = config.selfKill
+        var playerKill = config.playerKill
+        var otherDeaths = config.otherDeaths
+
+        category.addEntry(
+            entries.startBooleanToggle(literal("selfKill"), config.selfKill)
+                .setDefaultValue(true)
+                .setSaveConsumer { selfKill = it }
+                .build(),
+        )
+        category.addEntry(
+            entries.startBooleanToggle(literal("playerKill"), config.playerKill)
+                .setDefaultValue(true)
+                .setSaveConsumer { playerKill = it }
+                .build(),
+        )
+        category.addEntry(
+            entries.startBooleanToggle(literal("otherDeaths"), config.otherDeaths)
+                .setDefaultValue(true)
+                .setSaveConsumer { otherDeaths = it }
+                .build(),
+        )
+
+        builder.setSavingRunnable {
+            SimplePlayerHeads.configManager.save(Config(selfKill, playerKill, otherDeaths))
+        }
+        builder.build()
+    }
+}
+
+//? if >=1.22 {
+/*private fun literal(text: String): Component = Component.literal(text)*/
+//?} elif >=1.19 {
+private fun literal(text: String): Text = Text.literal(text)
+//?} else {
+/*private fun literal(text: String): Text = LiteralText(text)*/
+//?}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,12 @@
 				"value": "online.slavok.heads.SimplePlayerHeads",
 				"adapter": "kotlin"
 			}
+		],
+		"modmenu": [
+			{
+				"value": "online.slavok.heads.ModMenuIntegration",
+				"adapter": "kotlin"
+			}
 		]
 	},
 	"mixins": [
@@ -31,6 +37,10 @@
 		"minecraft": "${minecraft_dep}",
 		"java": ">=${java_level}",
 		"fabric-api": "*",
-		"fabric-language-kotlin": "*"
+		"fabric-language-kotlin": "*",
+		"cloth-config": "*"
+	},
+	"suggests": {
+		"modmenu": "*"
 	}
 }


### PR DESCRIPTION
Stacked on #7 (PR 6). Merge after PR 6.

A tiny in-game config screen (the three toggles) reachable from **Mod Menu**, on every supported version — **1.18.2 → 26.2**.

## What
- `ModMenuIntegration`: a Cloth Config screen; **Save** writes through `ConfigManager.save`. The text factory is branched three ways (`LiteralText` <1.19 / `Text.literal` 1.19–1.21.x / `Component.literal` 26+).
- Matrix: per-version **cloth** + **modmenu**. Cloth Config is **bundled (jar-in-jar)** so the screen works without a separate install; ModMenu is compile-only + a `suggests` (no ModMenu just means no screen — the config still works from the file, including on servers).
- `fabric.mod.json`: `modmenu` entrypoint, `cloth-config` depend, `modmenu` suggest.
- Repos: TerraformersMC, Shedaniel, Nucleoid (`placeholder-api`, a transitive of older ModMenu).

## Risk
The screen is a **client GUI**, so it can't be gametested headlessly. It's compiled against the exact Cloth/ModMenu version for each MC, which catches API drift at build time; a manual in-game check is still recommended.

## Test
All 7 yarn versions build (JDK 21) and 26.2 builds (JDK 25) with the screen. Verified the jar bundles `cloth-config-fabric` via jar-in-jar and does **not** bundle ModMenu.