### PR TITLE
PR 8: Release pipeline (GitHub Release + Modrinth)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: release
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # JDK 25 runs the daemon (so the 26+ nodes register); 17 and 21 are the
+      # toolchains the yarn versions compile against.
+      - uses: actions/setup-java@v4
+        with:
+          java-version: |
+            17
+            21
+            25
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v4
+
+      # Build every version's jar (no gametest boot).
+      - run: ./gradlew assemble --stacktrace
+
+      # softprops has no exclude patterns, so stage only the loadable (non-sources) jars.
+      - name: Collect release jars
+        run: |
+          mkdir -p release-jars
+          find versions -path '*/build/libs/*.jar' ! -name '*-sources.jar' -exec cp {} release-jars/ \;
+          ls -la release-jars
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: release-jars/*.jar
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+
+      - name: Publish to Modrinth
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+        run: ./gradlew publishMods --stacktrace

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simple Player Heads
 
-This is a Fabric mod for Minecraft 1.21 for customizing player head drop
+This is a Fabric mod for customizing player head drops. It supports Minecraft **1.18.2 through 26.2** from a single source (built per version with [Stonecutter](https://stonecutter.kikugie.dev/)).
 
 ## Features
 
@@ -37,3 +37,22 @@ You can also edit these options in-game from the [Mod Menu](https://modrinth.com
 
 1. Download the latest release of Simple Player Heads from [here](https://modrinth.com/mod/simple-player-heads).
 2. Place the `.jar` file in your `mods` folder.
+
+## Building
+
+`./gradlew build` builds a jar per supported version into `versions/<version>/build/libs/`.
+The yarn range (1.18.2–1.21.8) builds on JDK 17/21; Minecraft 26+ is unobfuscated and
+only builds on JDK 25.
+
+## Releasing
+
+CI publishes automatically on a `v*` tag (see `.github/workflows/release.yml`):
+it attaches every version's jar to a GitHub Release and publishes each to Modrinth.
+
+One-time setup:
+
+1. Create the project on [Modrinth](https://modrinth.com) and set `modrinth_id` in
+   `gradle.properties` to its id or slug (it is public, safe to commit).
+2. Add a repository Actions secret `MODRINTH_TOKEN` — a Modrinth PAT with the
+   "Create versions" scope.
+3. Cut a release by pushing a tag, e.g. `git tag v1.0.2 && git push origin v1.0.2`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,10 @@
+import me.modmuss50.mpp.ReleaseType
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+
 plugins {
     id("dev.kikugie.stonecutter")
     id("fabric-loom") version "1.17.17"
+    id("me.modmuss50.mod-publish-plugin") version "2.1.1"
     kotlin("jvm") version "2.4.10"
     kotlin("plugin.serialization") version "2.4.10"
 }
@@ -96,4 +100,23 @@ java {
 
 kotlin {
     jvmToolchain(mc.java)
+}
+
+// Each version node publishes itself as one Modrinth version (`./gradlew publishMods`).
+publishMods {
+    file = tasks.named<AbstractArchiveTask>("remapJar").flatMap { it.archiveFile }
+    type = ReleaseType.STABLE
+    modLoaders.add("fabric")
+    version = project.version.toString()
+    displayName = "Simple Player Heads ${project.version}"
+    changelog = "See https://github.com/iSlavok/Simple-Player-Heads/releases"
+
+    modrinth {
+        projectId = providers.gradleProperty("modrinth_id")
+        accessToken = providers.environmentVariable("MODRINTH_TOKEN")
+        minecraftVersions.addAll(mc.gameVersions)
+        requires("fabric-api")
+        requires("fabric-language-kotlin")
+        optional("modmenu")
+    }
 }

--- a/build.unobfuscated.gradle.kts
+++ b/build.unobfuscated.gradle.kts
@@ -1,6 +1,10 @@
+import me.modmuss50.mpp.ReleaseType
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+
 plugins {
     id("dev.kikugie.stonecutter")
     id("net.fabricmc.fabric-loom") version "1.17.17" // non-remapping variant (Minecraft 26+ ships unobfuscated)
+    id("me.modmuss50.mod-publish-plugin") version "2.1.1"
     kotlin("jvm") version "2.4.10"
     kotlin("plugin.serialization") version "2.4.10"
 }
@@ -75,4 +79,23 @@ java {
 
 kotlin {
     jvmToolchain(javaVersion)
+}
+
+// Publish the non-remapped jar (unobfuscated 26+ has no remapJar).
+publishMods {
+    file = tasks.named<AbstractArchiveTask>("jar").flatMap { it.archiveFile }
+    type = ReleaseType.STABLE
+    modLoaders.add("fabric")
+    version = project.version.toString()
+    displayName = "Simple Player Heads ${project.version}"
+    changelog = "See https://github.com/iSlavok/Simple-Player-Heads/releases"
+
+    modrinth {
+        projectId = providers.gradleProperty("modrinth_id")
+        accessToken = providers.environmentVariable("MODRINTH_TOKEN")
+        minecraftVersions.addAll(u.gameVersions)
+        requires("fabric-api")
+        requires("fabric-language-kotlin")
+        optional("modmenu")
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,6 @@ archives_base_name=simple-player-heads
 # Per-Minecraft-version deps (yarn, Fabric API, ModMenu, ...) live in the build script matrix.
 loader_version=0.19.3
 fabric_kotlin_version=1.13.13+kotlin.2.4.10
+
+# Modrinth project id or slug (public; safe to commit). Used by `./gradlew publishMods`.
+modrinth_id=simple-player-heads


### PR DESCRIPTION
Stacked on #8 (PR 7). Final PR. Delivers the release half of goal #3.

## What
- **mod-publish-plugin** (2.1.1) in both build scripts. Each version node publishes itself as one Modrinth version with its own **non-overlapping** game versions. Declares `fabric-api` + `fabric-language-kotlin` as required and `modmenu` as optional; Cloth Config is bundled, so it is not a Modrinth dependency.
- **`release.yml`** on tag `v*`: installs JDK 17/21/25 (yarn toolchains + a JDK 25 daemon so the 26+ nodes register), `assemble`, attaches every non-sources jar to a **GitHub Release** (staged for `softprops`, which has no exclude patterns), then `publishMods` to **Modrinth**.
- `gradle.properties`: `modrinth_id`.
- README: build + release instructions and the `MODRINTH_TOKEN` one-time setup.

## One-time manual setup (before the first release)
1. Create the Modrinth project; set `modrinth_id` to its id/slug.
2. Add repo Actions secret `MODRINTH_TOKEN` (PAT, "Create versions" scope).
3. Push a tag, e.g. `git tag v1.0.2 && git push origin v1.0.2`.

## Test
Build stays green with the plugin applied. `publishMods --dry-run` resolves `publishModrinth` for **all 8 version nodes** (7 yarn on JDK 21, 26.2 on JDK 25). Actual publishing needs the secret + tag, so it can only run on your repo.