### PR TITLE
PR 9: Tag-driven release version + real Modrinth id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,19 @@ jobs:
           distribution: temurin
       - uses: gradle/actions/setup-gradle@v4
 
+      # The mod version comes from the tag (v1.0.2 -> 1.0.2), overriding the
+      # gradle.properties default. Manual workflow_dispatch runs keep that default.
+      - name: Resolve version from tag
+        id: ver
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "arg=-Pmod_version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "arg=" >> "$GITHUB_OUTPUT"
+          fi
+
       # Build every version's jar (no gametest boot).
-      - run: ./gradlew assemble --stacktrace
+      - run: ./gradlew assemble ${{ steps.ver.outputs.arg }} --stacktrace
 
       # softprops has no exclude patterns, so stage only the loadable (non-sources) jars.
       - name: Collect release jars
@@ -41,4 +52,4 @@ jobs:
       - name: Publish to Modrinth
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
-        run: ./gradlew publishMods --stacktrace
+        run: ./gradlew publishMods ${{ steps.ver.outputs.arg }} --stacktrace

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ only builds on JDK 25.
 
 CI publishes automatically on a `v*` tag (see `.github/workflows/release.yml`):
 it attaches every version's jar to a GitHub Release and publishes each to Modrinth.
+The released version is taken **from the tag** (`v1.0.2` → `1.0.2`), so you do not
+edit `mod_version` for a release — just tag. (`mod_version` in `gradle.properties`
+is only the default for local dev builds.)
 
 One-time setup:
 
@@ -55,4 +58,5 @@ One-time setup:
    `gradle.properties` to its id or slug (it is public, safe to commit).
 2. Add a repository Actions secret `MODRINTH_TOKEN` — a Modrinth PAT with the
    "Create versions" scope.
-3. Cut a release by pushing a tag, e.g. `git tag v1.0.2 && git push origin v1.0.2`.
+
+Then release by pushing a tag: `git tag v1.0.2 && git push origin v1.0.2`.

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,4 @@ loader_version=0.19.3
 fabric_kotlin_version=1.13.13+kotlin.2.4.10
 
 # Modrinth project id or slug (public; safe to commit). Used by `./gradlew publishMods`.
-modrinth_id=simple-player-heads
+modrinth_id=n24AL2Sz


### PR DESCRIPTION
Follow-up to the release pipeline. Makes a release **just a tag** — no manual version bump in the project.

## Why
`mod_version` in `gradle.properties` was the single source of the jar/Modrinth version, so releasing meant editing it *and* tagging, kept in sync by hand. This wires the version to the tag instead.

## What
- `release.yml`: the mod version is derived from the tag (`v1.0.2` → `1.0.2`) and passed as `-Pmod_version`, which overrides the `gradle.properties` default. Manual `workflow_dispatch` runs fall back to that default.
- `gradle.properties`: `modrinth_id` set to the real project id (`n24AL2Sz`); it stays the default for local dev builds only.
- README: documents tag-driven versioning.

## Test
`./gradlew :1.21.8:assemble -Pmod_version=9.9.9` produces `simple-player-heads-9.9.9+mc1.21.8.jar` — the override reaches the jar and (identically) the Modrinth version.

## Release flow now
`git tag v1.0.2 && git push origin v1.0.2` — that's it.