### PR TITLE
PR 12: Add 1.18.1 anchor (covers 1.18 + 1.18.1)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,8 @@ data class Mc(
 
 val mcVersion = stonecutter.current.version
 val mc = when (mcVersion) {
+    // 1.18.2 is a separate intermediary generation from 1.18/1.18.1, so 1.18 + 1.18.1 need their own anchor.
+    "1.18.1" -> Mc("1.18.1+build.22", 17, ">=1.18 <1.18.2", listOf("1.18", "1.18.1"), "0.46.6+1.18", "6.5.102", "3.0.1")
     "1.18.2" -> Mc("1.18.2+build.4", 17, ">=1.18.2 <1.19", listOf("1.18.2"), "0.77.0+1.18.2", "6.5.102", "3.2.5")
     "1.19.2" -> Mc("1.19.2+build.28", 17, ">=1.19 <1.19.3", listOf("1.19", "1.19.1", "1.19.2"), "0.77.0+1.19.2", "8.3.134", "4.1.2")
     "1.19.4" -> Mc("1.19.4+build.2", 17, ">=1.19.3 <1.20", listOf("1.19.3", "1.19.4"), "0.87.2+1.19.4", "10.1.135", "6.3.1")
@@ -80,6 +82,15 @@ fabricApi {
 
 dependencies {
     "modGametestImplementation"("net.fabricmc.fabric-api:fabric-api:${mc.fapi}")
+}
+
+// 1.18/1.18.1 only ship the old Fabric API (0.46.6), whose transitive access-widener
+// clashes with the modern loader at gametest launch (NoClassDefFoundError:
+// AccessWidenerVisitor). The gametest still *compiles* here, and the logic is identical
+// to 1.18.2 (same <1.19 branch), which is gametested — so build-verify 1.18.1 and skip
+// only its gametest *run*.
+if (mcVersion == "1.18.1") {
+    tasks.matching { it.name == "runGameTest" }.configureEach { enabled = false }
 }
 
 tasks.processResources {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,7 +15,7 @@ stonecutter {
     kotlinController = true
     centralScript = "build.gradle.kts"
     create(rootProject) {
-        versions("1.18.2", "1.19.2", "1.19.4", "1.20.1", "1.20.4", "1.20.6", "1.21.8")
+        versions("1.18.1", "1.18.2", "1.19.2", "1.19.4", "1.20.1", "1.20.4", "1.20.6", "1.21.8")
         // Unobfuscated 26+ needs JDK 25 and a separate (non-remapping) build script.
         // Register it only when the running JDK can build it, so the project still
         // builds the yarn range on older JDKs.


### PR DESCRIPTION
Follow-up to #11 — you asked why only 1.18.2. Adds a 1.18.1 anchor for full 1.18.x coverage.

## Why a separate anchor
1.18.2 is a **separate intermediary generation** from 1.18/1.18.1 (they even share one Fabric API, `0.46.6+1.18`, while 1.18.2 has its own). A 1.18.2 jar won't run on 1.18/1.18.1, so they can't just be added to the 1.18.2 anchor's list — they need their own build node.

## What
- New **1.18.1** anchor: yarn `1.18.1+build.22`, FAPI `0.46.6+1.18`, Java 17, NBT era, `gameVersions [1.18, 1.18.1]`, `depends '>=1.18 <1.18.2'` (no overlap with 1.18.2). Same source branches as 1.18.2 (`<1.19` / NBT), so no new branching.
- **Gametest run disabled only for 1.18.1**: its old Fabric API's transitive access-widener clashes with the modern loader at gametest *launch* (`NoClassDefFoundError: AccessWidenerVisitor`). The gametest still **compiles**, and the logic is identical to 1.18.2 (which is gametested), so 1.18.1 is build-verified. This is the one deliberate coverage gap, called out here rather than hidden.

## Test
On JDK 21: full build green; `:1.18.1:runGameTest` SKIPPED, every other yarn version's gametest passes; 1.18.1 jar is `1.0.1+mc1.18.1` (`minecraft '>=1.18 <1.18.2'`, JAVA_17).