### PR TITLE
Add server-side Bukkit plugin (Spigot/Paper/Purpur/Folia)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,23 @@ jobs:
           path: versions/*/build/libs/*.jar
           if-no-files-found: error
 
+  # Standalone Bukkit plugin build — one JDK 21 job, independent of the mod's version grid.
+  plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v4
+      - run: ./gradlew -p plugin build --stacktrace
+      - uses: actions/upload-artifact@v4
+        with:
+          name: plugin-jar
+          path: plugin/build/libs/*.jar
+          if-no-files-found: error
+
   # Unobfuscated 26+ needs JDK 25; settings only registers those nodes on JDK 25+.
   build-unobfuscated:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ You can also edit these options in-game from the [Mod Menu](https://modrinth.com
 1. Download the latest release of Simple Player Heads from [here](https://modrinth.com/mod/simple-player-heads).
 2. Place the `.jar` file in your `mods` folder.
 
+## Server Plugin (Bukkit/Spigot/Paper/Purpur/Folia)
+
+For servers without a Fabric client mod, a Bukkit plugin reproduces the head-drop
+behavior. It lives in `plugin/` as a standalone build.
+
+- **Build:** `./gradlew -p plugin build` → `plugin/build/libs/simple-player-heads-plugin-<version>.jar`
+- **Run for testing:** `./gradlew -p plugin runServer` (downloads Paper; override the
+  Minecraft version with `-Prun_mc=1.20.6`).
+- **Install:** drop the jar in the server's `plugins/` folder.
+- **Config:** `plugins/SimplePlayerHeads/config.yml` with the same `selfKill`,
+  `playerKill`, `otherDeaths` flags. Edit and restart/reload the server to apply.
+
+One jar runs Spigot, Paper, Purpur and Folia (it declares `folia-supported: true`).
+
 ## Building
 
 `./gradlew build` builds a jar per supported version into `versions/<version>/build/libs/`.

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -53,3 +53,12 @@ tasks.processResources {
     inputs.properties(props)
     filesMatching("plugin.yml") { expand(props) }
 }
+
+tasks.runServer {
+    val mc = providers.gradleProperty("run_mc").getOrElse("1.21.8")
+    minecraftVersion(mc)
+    // Paper for MC 26+ requires Java 25; older run on 21.
+    javaLauncher.set(javaToolchains.launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(if (mc.substringBefore(".").toInt() >= 26) 25 else 21))
+    })
+}

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,0 +1,55 @@
+plugins {
+    kotlin("jvm") version "2.4.10"
+    id("com.gradleup.shadow") version "9.6.0"
+    id("xyz.jpenilla.run-paper") version "3.0.2"
+}
+
+group = providers.gradleProperty("maven_group").get()
+version = providers.gradleProperty("plugin_version").get()
+
+repositories {
+    mavenCentral()
+    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/") // spigot-api
+    maven("https://repo.papermc.io/repository/maven-public/")               // paper-api (tests)
+    maven("https://oss.sonatype.org/content/repositories/snapshots/")       // spigot-api transitives
+}
+
+dependencies {
+    compileOnly("org.spigotmc:spigot-api:${property("spigot_api_version")}")
+    implementation(kotlin("stdlib")) // shaded into the plugin jar (server has no Kotlin runtime)
+
+    testImplementation("io.papermc.paper:paper-api:${property("paper_api_version")}")
+    testImplementation("org.mockbukkit.mockbukkit:mockbukkit-v1.21:${property("mockbukkit_version")}")
+    testImplementation("org.junit.jupiter:junit-jupiter:${property("junit_version")}")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+java {
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+// Shaded jar is the artifact servers load; keep the thin jar out of its way.
+tasks.jar {
+    archiveClassifier.set("thin")
+}
+tasks.shadowJar {
+    archiveClassifier.set("")
+}
+tasks.build {
+    dependsOn(tasks.shadowJar)
+}
+
+// Inject the project version into plugin.yml.
+tasks.processResources {
+    val props = mapOf("version" to project.version)
+    inputs.properties(props)
+    filesMatching("plugin.yml") { expand(props) }
+}

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -5,7 +5,9 @@ maven_group=online.slavok
 
 kotlin_version=2.4.10
 spigot_api_version=1.21.8-R0.1-SNAPSHOT
-paper_api_version=1.21.8-R0.1-SNAPSHOT
+# Must match the Paper API version MockBukkit was built against, or MockBukkit throws
+# IncompatiblePaperVersionException (test-only; the plugin compiles against spigot-api).
+paper_api_version=1.21.11-R0.1-SNAPSHOT
 mockbukkit_version=4.108.0
 junit_version=5.11.4
 shadow_version=9.6.0

--- a/plugin/gradle.properties
+++ b/plugin/gradle.properties
@@ -1,0 +1,15 @@
+org.gradle.jvmargs=-Xmx2G
+
+plugin_version=1.0.1
+maven_group=online.slavok
+
+kotlin_version=2.4.10
+spigot_api_version=1.21.8-R0.1-SNAPSHOT
+paper_api_version=1.21.8-R0.1-SNAPSHOT
+mockbukkit_version=4.108.0
+junit_version=5.11.4
+shadow_version=9.6.0
+run_paper_version=3.0.2
+
+# Same Modrinth project as the mod (used by the follow-up publishing plan).
+modrinth_id=n24AL2Sz

--- a/plugin/settings.gradle.kts
+++ b/plugin/settings.gradle.kts
@@ -1,0 +1,8 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "simple-player-heads-plugin"

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadConfig.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadConfig.kt
@@ -1,0 +1,8 @@
+package online.slavok.heads.plugin
+
+/** The three gameplay flags, mirrored from the mod's config. */
+data class HeadConfig(
+    val selfKill: Boolean = true,
+    val playerKill: Boolean = true,
+    val otherDeaths: Boolean = true,
+)

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadDropDecision.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadDropDecision.kt
@@ -1,0 +1,14 @@
+package online.slavok.heads.plugin
+
+/**
+ * Pure decision: given the config and how the victim died, should a head be produced?
+ * Mirrors the mod's shouldDropHead. `killerIsSelf` is only meaningful when `killerIsPlayer`.
+ */
+object HeadDropDecision {
+    fun shouldDrop(config: HeadConfig, killerIsPlayer: Boolean, killerIsSelf: Boolean): Boolean =
+        when {
+            killerIsPlayer && killerIsSelf -> config.selfKill
+            killerIsPlayer -> config.playerKill
+            else -> config.otherDeaths
+        }
+}

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/PlayerDeathListener.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/PlayerDeathListener.kt
@@ -1,0 +1,42 @@
+package online.slavok.heads.plugin
+
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.entity.PlayerDeathEvent
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.SkullMeta
+
+/**
+ * Bukkit counterpart of the mod's ServerPlayer.die mixin. `victim.killer` already resolves a
+ * projectile to its shooting player (or null), mirroring the mod's DamageSource.getAttacker().
+ */
+class PlayerDeathListener(private val configProvider: () -> HeadConfig) : Listener {
+
+    // PlayerDeathEvent is not Cancellable, so no ignoreCancelled here.
+    @EventHandler
+    fun onDeath(event: PlayerDeathEvent) {
+        val victim = event.entity
+        val killer: Player? = victim.killer
+        val shouldDrop = HeadDropDecision.shouldDrop(
+            config = configProvider(),
+            killerIsPlayer = killer != null,
+            killerIsSelf = killer != null && killer == victim,
+        )
+        if (!shouldDrop) return
+
+        val head = createHead(victim)
+        // Mirror the mod: head joins the death drops by default; with keepInventory it stays on the player.
+        if (event.keepInventory) victim.inventory.addItem(head)
+        else event.drops.add(head)
+    }
+
+    private fun createHead(owner: Player): ItemStack {
+        val head = ItemStack(Material.PLAYER_HEAD)
+        val meta = head.itemMeta as SkullMeta
+        meta.owningPlayer = owner
+        head.itemMeta = meta
+        return head
+    }
+}

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/SimplePlayerHeadsPlugin.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/SimplePlayerHeadsPlugin.kt
@@ -1,0 +1,22 @@
+package online.slavok.heads.plugin
+
+import org.bukkit.plugin.java.JavaPlugin
+
+// `open` so MockBukkit can subclass it (Kotlin classes are final by default).
+open class SimplePlayerHeadsPlugin : JavaPlugin() {
+
+    override fun onEnable() {
+        saveDefaultConfig()
+        server.pluginManager.registerEvents(PlayerDeathListener(::readConfig), this)
+    }
+
+    /** Read live, so a config reload/restart is picked up on the next death. */
+    private fun readConfig(): HeadConfig {
+        val c = config
+        return HeadConfig(
+            selfKill = c.getBoolean("selfKill", true),
+            playerKill = c.getBoolean("playerKill", true),
+            otherDeaths = c.getBoolean("otherDeaths", true),
+        )
+    }
+}

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -1,0 +1,6 @@
+# If true, player will get his head after self kill
+selfKill: true
+# If true, player will get his head after kill by another player
+playerKill: true
+# If true, player will get his head after all other deaths
+otherDeaths: true

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: SimplePlayerHeads
+version: ${version}
+main: online.slavok.heads.plugin.SimplePlayerHeadsPlugin
+api-version: "1.18"
+folia-supported: true
+description: Drops a player head on death, configurable per death cause.
+author: iSlavok
+website: https://github.com/iSlavok/Simple-Player-Heads

--- a/plugin/src/test/kotlin/online/slavok/heads/plugin/HeadDropDecisionTest.kt
+++ b/plugin/src/test/kotlin/online/slavok/heads/plugin/HeadDropDecisionTest.kt
@@ -1,0 +1,34 @@
+package online.slavok.heads.plugin
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HeadDropDecisionTest {
+
+    @Test
+    fun `self kill follows selfKill flag`() {
+        assertTrue(HeadDropDecision.shouldDrop(HeadConfig(selfKill = true), killerIsPlayer = true, killerIsSelf = true))
+        assertFalse(HeadDropDecision.shouldDrop(HeadConfig(selfKill = false), killerIsPlayer = true, killerIsSelf = true))
+    }
+
+    @Test
+    fun `player kill follows playerKill flag`() {
+        assertTrue(HeadDropDecision.shouldDrop(HeadConfig(playerKill = true), killerIsPlayer = true, killerIsSelf = false))
+        assertFalse(HeadDropDecision.shouldDrop(HeadConfig(playerKill = false), killerIsPlayer = true, killerIsSelf = false))
+    }
+
+    @Test
+    fun `other death follows otherDeaths flag`() {
+        assertTrue(HeadDropDecision.shouldDrop(HeadConfig(otherDeaths = true), killerIsPlayer = false, killerIsSelf = false))
+        assertFalse(HeadDropDecision.shouldDrop(HeadConfig(otherDeaths = false), killerIsPlayer = false, killerIsSelf = false))
+    }
+
+    @Test
+    fun `self kill flag is independent of the other flags`() {
+        val config = HeadConfig(selfKill = true, playerKill = false, otherDeaths = false)
+        assertTrue(HeadDropDecision.shouldDrop(config, killerIsPlayer = true, killerIsSelf = true))
+        assertFalse(HeadDropDecision.shouldDrop(config, killerIsPlayer = true, killerIsSelf = false))
+        assertFalse(HeadDropDecision.shouldDrop(config, killerIsPlayer = false, killerIsSelf = false))
+    }
+}

--- a/plugin/src/test/kotlin/online/slavok/heads/plugin/PluginLoadTest.kt
+++ b/plugin/src/test/kotlin/online/slavok/heads/plugin/PluginLoadTest.kt
@@ -1,0 +1,36 @@
+package online.slavok.heads.plugin
+
+import org.bukkit.event.entity.PlayerDeathEvent
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+
+class PluginLoadTest {
+    private lateinit var server: ServerMock
+    private lateinit var plugin: SimplePlayerHeadsPlugin
+
+    @BeforeEach
+    fun setUp() {
+        server = MockBukkit.mock()
+        plugin = MockBukkit.load(SimplePlayerHeadsPlugin::class.java)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MockBukkit.unmock()
+    }
+
+    @Test
+    fun `plugin enables`() {
+        assertTrue(plugin.isEnabled)
+    }
+
+    @Test
+    fun `registers a player death listener`() {
+        val registered = PlayerDeathEvent.getHandlerList().registeredListeners
+        assertTrue(registered.any { it.plugin === plugin })
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,11 @@ plugins {
     id("dev.kikugie.stonecutter") version "0.9.7"
 }
 
+// Standalone plugin build — surfaced to the IDE only; it is NOT pulled into the root
+// `build` (which would configure the whole Loom/Minecraft matrix). Build it with
+// `./gradlew -p plugin build`.
+includeBuild("plugin")
+
 stonecutter {
     kotlinController = true
     centralScript = "build.gradle.kts"


### PR DESCRIPTION
Ports the mod's server-side behavior to a Bukkit plugin so servers without a Fabric client mod get the same head-drop feature. The existing Fabric mod is untouched.

## What's new
- **`plugin/`** — a **standalone** Gradle build (its own `settings.gradle.kts`), kept out of the mod's Stonecutter/Loom grid. Build with `./gradlew -p plugin build`. Root `settings.gradle.kts` gets `includeBuild("plugin")` for IDE visibility only.
- **Kotlin plugin**, one shaded jar (`kotlin-stdlib` bundled, ~1.8 MB) that runs the whole fork chain: compiled against `spigot-api` (`compileOnly`), `folia-supported: true`, `api-version: "1.18"`.
- **`PlayerDeathListener`** mirrors the mod's `ServerPlayer.die` mixin: classifies the killer via `victim.killer` (Bukkit resolves projectile → shooter) into `selfKill` / `playerKill` / `otherDeaths`, then adds a `SkullMeta`-stamped `PLAYER_HEAD` to the death drops (or the inventory under keepInventory).
- **Config**: YAML `config.yml` with the same three flags; no in-game commands (the mod's ModMenu/Cloth screen is client-side and does not port).

## Behavior parity
| Mod | Plugin |
|---|---|
| `damageSource.attacker` (resolves projectile shooter) | `victim.killer` |
| attacker == victim | `killer == victim` → `selfKill` |
| attacker is player | `killer != null` → `playerKill` |
| otherwise | `killer == null` → `otherDeaths` |
| `inventory.insertStack` at HEAD of `die()` | `event.drops.add` (or `inventory.addItem` under keepInventory) |

## Testing
- `HeadDropDecisionTest` — pure JUnit, all flag/killer combinations (4 tests).
- `PluginLoadTest` — MockBukkit load smoke; plugin enables + registers the listener (2 tests). Test `paper-api` pinned to `1.21.11` to match MockBukkit 4.108.0.
- Real Paper boot via `run-paper`: `Enabling SimplePlayerHeads v1.0.1` → `Done`, `config.yml` generated correctly.
- New `plugin` CI job builds + tests on JDK 21.

## Follow-up (separate PR)
Publish the plugin to the same Modrinth project (`n24AL2Sz`) with loaders `bukkit`/`spigot`/`paper`/`purpur`/`folia` — needs `mod-publish-plugin` config + a distinct version slug to avoid colliding with the mod's versions.