### PR TITLE
Publish the plugin to Modrinth on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,16 @@ jobs:
       # Build every version's jar (no gametest boot).
       - run: ./gradlew assemble ${{ steps.ver.outputs.arg }} --stacktrace
 
+      # Build the standalone Bukkit plugin jar too (its own build, JDK 21 toolchain).
+      - run: ./gradlew -p plugin build ${{ steps.ver.outputs.arg }} --stacktrace
+
       # softprops has no exclude patterns, so stage only the loadable (non-sources) jars.
+      # For the plugin, skip the thin (non-shaded) jar.
       - name: Collect release jars
         run: |
           mkdir -p release-jars
           find versions -path '*/build/libs/*.jar' ! -name '*-sources.jar' -exec cp {} release-jars/ \;
+          find plugin/build/libs -name '*.jar' ! -name '*-thin.jar' ! -name '*-sources.jar' -exec cp {} release-jars/ \;
           ls -la release-jars
       - uses: softprops/action-gh-release@v2
         with:
@@ -49,7 +54,13 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
 
-      - name: Publish to Modrinth
+      - name: Publish mod to Modrinth
         env:
           MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
         run: ./gradlew publishMods ${{ steps.ver.outputs.arg }} --stacktrace
+
+      # Standalone plugin → same Modrinth project, plugin loaders, "+plugin" version suffix.
+      - name: Publish plugin to Modrinth
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+        run: ./gradlew -p plugin publishMods ${{ steps.ver.outputs.arg }} --stacktrace

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ behavior. It lives in `plugin/` as a standalone build.
 - **Build:** `./gradlew -p plugin build` → `plugin/build/libs/simple-player-heads-plugin-<version>.jar`
 - **Run for testing:** `./gradlew -p plugin runServer` (downloads Paper; override the
   Minecraft version with `-Prun_mc=1.20.6`).
-- **Install:** drop the jar in the server's `plugins/` folder.
+- **Install:** download the plugin jar from the same
+  [Modrinth project](https://modrinth.com/mod/simple-player-heads) (filter by the
+  Bukkit/Paper/Folia loaders) or build it, then drop it in the server's `plugins/` folder.
 - **Config:** `plugins/SimplePlayerHeads/config.yml` with the same `selfKill`,
   `playerKill`, `otherDeaths` flags. Edit and restart/reload the server to apply.
 

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,11 +1,17 @@
+import me.modmuss50.mpp.ReleaseType
+
 plugins {
     kotlin("jvm") version "2.4.10"
     id("com.gradleup.shadow") version "9.6.0"
     id("xyz.jpenilla.run-paper") version "3.0.2"
+    id("me.modmuss50.mod-publish-plugin") version "2.1.1"
 }
 
 group = providers.gradleProperty("maven_group").get()
-version = providers.gradleProperty("plugin_version").get()
+// On a tag release the workflow passes -Pmod_version (same as the mod build); fall back to the
+// local plugin_version default otherwise.
+version = providers.gradleProperty("mod_version")
+    .getOrElse(providers.gradleProperty("plugin_version").get())
 
 repositories {
     mavenCentral()
@@ -61,4 +67,30 @@ tasks.runServer {
     javaLauncher.set(javaToolchains.launcherFor {
         languageVersion.set(JavaLanguageVersion.of(if (mc.substringBefore(".").toInt() >= 26) 25 else 21))
     })
+}
+
+// Publish the shaded jar to the SAME Modrinth project as the mod, tagged with the plugin loaders.
+// The version string gets a distinct "+plugin" suffix so it never collides with the mod's
+// per-Minecraft-version releases (Modrinth version numbers must be unique per project).
+publishMods {
+    // No token (local) → dry run: writes the payload under build/ without uploading.
+    // CI provides MODRINTH_TOKEN, so a tagged release publishes for real.
+    dryRun = providers.environmentVariable("MODRINTH_TOKEN").map { false }.orElse(true)
+    file = tasks.shadowJar.flatMap { it.archiveFile }
+    type = ReleaseType.STABLE
+    modLoaders.addAll("bukkit", "spigot", "paper", "purpur", "folia")
+    version = "${project.version}+plugin"
+    displayName = "Simple Player Heads ${project.version} (Plugin)"
+    changelog = "See https://github.com/iSlavok/Simple-Player-Heads/releases"
+
+    modrinth {
+        projectId = providers.gradleProperty("modrinth_id")
+        accessToken = providers.environmentVariable("MODRINTH_TOKEN")
+        // One Bukkit-API jar spans the whole range; let mod-publish-plugin resolve the concrete
+        // version list from Modrinth at publish time. The plugin has no dependencies.
+        minecraftVersionRange {
+            start = "1.18"
+            end = "26.2"
+        }
+    }
 }


### PR DESCRIPTION
Wires the standalone Bukkit plugin (added in #13) into the release pipeline so it publishes to the **same** Modrinth project as the mod (`n24AL2Sz`), tagged with the plugin loaders.

## Changes
- **`plugin/build.gradle.kts`**: add `me.modmuss50.mod-publish-plugin` with a `publishMods` block.
  - `modLoaders.addAll("bukkit", "spigot", "paper", "purpur", "folia")` (Modrinth `modLoaders` is free-form).
  - Version string `"${version}+plugin"` — a distinct suffix so it never collides with the mod's per-Minecraft-version releases (Modrinth version numbers must be unique per project).
  - `minecraftVersionRange { start = "1.18"; end = "26.2" }` — one Bukkit-API jar spans the range; the concrete list is resolved from Modrinth at publish time. No dependencies declared (the plugin has none).
  - Plugin version now honors `-Pmod_version` (same override the mod build uses), so a tag release aligns the plugin version with the mod.
  - `dryRun` auto-enables when `MODRINTH_TOKEN` is absent, so a local `./gradlew -p plugin publishMods` validates the payload without uploading.
- **`.github/workflows/release.yml`**: build the plugin jar, attach it to the GitHub release (excluding the thin jar), and add a `Publish plugin to Modrinth` step (`./gradlew -p plugin publishMods`).
- **`README.md`**: note the plugin is available from the same Modrinth project.

## Verification
Local dry run (no token) resolved the config end-to-end:
```
Dry run publishModrinth:
Main file: simple-player-heads-plugin-1.0.1.jar
Display name: Simple Player Heads 1.0.1 (Plugin)
Version: 1.0.1+plugin
```
`release.yml` validated (YAML parses; publish steps present). Publishing itself runs on the next `v*` tag using the existing `MODRINTH_TOKEN` secret — nothing is published by this PR.

## Note
Per the skill guidance, the very first tagged release is the real end-to-end test of the multi-loader publish (a `dryRun` does not resolve the concrete version list). Worth watching the first `v*` run.