### PR TITLE
feat: per-Looting-level head drop chance on player kill (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ The default configuration file is `config\simple-player-heads.toml`:
 selfKill = true
 playerKill = true
 otherDeaths = true
+
+[playerKillLooting]
+enabled = false
+noLooting = 1.0
+looting1 = 1.0
+looting2 = 1.0
+looting3 = 1.0
 ```
 
 **Configuration options:**
@@ -29,6 +36,12 @@ otherDeaths = true
 - `selfKill`: If true, player will get his head after self kill
 - `playerKill`: If true, player will get his head after kill by another player
 - `otherDeaths`: If true, player will get his head after all other deaths
+- `playerKillLooting.enabled`: If true, a player-kill head drop uses the per-Looting-level
+  chances below instead of always dropping. Requires `playerKill = true`.
+- `playerKillLooting.noLooting` / `looting1` / `looting2` / `looting3`: Drop chance
+  (`0.0`–`1.0`) when the killer's weapon has no Looting / Looting I / II / III. Looting
+  above III uses `looting3`. Example: `noLooting = 0.0`, `looting3 = 1.0` drops a head
+  only when the killer used a Looting III weapon.
 
 You can also edit these options in-game from the [Mod Menu](https://modrinth.com/mod/modmenu) config screen (Cloth Config is bundled).
 
@@ -50,7 +63,9 @@ behavior. It lives in `plugin/` as a standalone build.
   [Modrinth project](https://modrinth.com/mod/simple-player-heads) (filter by the
   Bukkit/Paper/Folia loaders) or build it, then drop it in the server's `plugins/` folder.
 - **Config:** `plugins/SimplePlayerHeads/config.yml` with the same `selfKill`,
-  `playerKill`, `otherDeaths` flags. Edit and restart/reload the server to apply.
+  `playerKill`, `otherDeaths` flags plus a `playerKillLooting` section (`enabled` +
+  `noLooting`/`looting1`/`looting2`/`looting3` drop chances). Edit and restart/reload
+  the server to apply.
 
 One jar runs Spigot, Paper, Purpur and Folia (it declares `folia-supported: true`).
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ otherDeaths = true
 
 [playerKillLooting]
 enabled = false
-noLooting = 1.0
-looting1 = 1.0
-looting2 = 1.0
+noLooting = 0.0
+looting1 = 0.33
+looting2 = 0.67
 looting3 = 1.0
 ```
 

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadConfig.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadConfig.kt
@@ -3,9 +3,9 @@ package online.slavok.heads.plugin
 /** Per-Looting-level drop chance for kills by another player. Mirrors the mod's config section. */
 data class PlayerKillLooting(
     val enabled: Boolean = false,
-    val noLooting: Double = 1.0,
-    val looting1: Double = 1.0,
-    val looting2: Double = 1.0,
+    val noLooting: Double = 0.0,
+    val looting1: Double = 0.33,
+    val looting2: Double = 0.67,
     val looting3: Double = 1.0,
 )
 

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadConfig.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadConfig.kt
@@ -1,8 +1,18 @@
 package online.slavok.heads.plugin
 
-/** The three gameplay flags, mirrored from the mod's config. */
+/** Per-Looting-level drop chance for kills by another player. Mirrors the mod's config section. */
+data class PlayerKillLooting(
+    val enabled: Boolean = false,
+    val noLooting: Double = 1.0,
+    val looting1: Double = 1.0,
+    val looting2: Double = 1.0,
+    val looting3: Double = 1.0,
+)
+
+/** The gameplay flags, mirrored from the mod's config. */
 data class HeadConfig(
     val selfKill: Boolean = true,
     val playerKill: Boolean = true,
     val otherDeaths: Boolean = true,
+    val playerKillLooting: PlayerKillLooting = PlayerKillLooting(),
 )

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadDropDecision.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/HeadDropDecision.kt
@@ -1,14 +1,31 @@
 package online.slavok.heads.plugin
 
 /**
- * Pure decision: given the config and how the victim died, should a head be produced?
- * Mirrors the mod's shouldDropHead. `killerIsSelf` is only meaningful when `killerIsPlayer`.
+ * Pure decision: given the config, how the victim died, and the killer's Looting level,
+ * what is the head's drop probability [0.0, 1.0]? Mirrors the mod's dropChance.
+ * `killerIsSelf` and `lootingLevel` are only meaningful when `killerIsPlayer`.
  */
 object HeadDropDecision {
-    fun shouldDrop(config: HeadConfig, killerIsPlayer: Boolean, killerIsSelf: Boolean): Boolean =
-        when {
-            killerIsPlayer && killerIsSelf -> config.selfKill
-            killerIsPlayer -> config.playerKill
-            else -> config.otherDeaths
+    fun dropChance(
+        config: HeadConfig,
+        killerIsPlayer: Boolean,
+        killerIsSelf: Boolean,
+        lootingLevel: Int,
+    ): Double = when {
+        killerIsPlayer && killerIsSelf -> if (config.selfKill) 1.0 else 0.0
+        killerIsPlayer -> playerKillChance(config, lootingLevel)
+        else -> if (config.otherDeaths) 1.0 else 0.0
+    }
+
+    private fun playerKillChance(config: HeadConfig, lootingLevel: Int): Double {
+        if (!config.playerKill) return 0.0
+        val looting = config.playerKillLooting
+        if (!looting.enabled) return 1.0
+        return when (lootingLevel.coerceIn(0, 3)) {
+            0 -> looting.noLooting
+            1 -> looting.looting1
+            2 -> looting.looting2
+            else -> looting.looting3
         }
+    }
 }

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/PlayerDeathListener.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/PlayerDeathListener.kt
@@ -19,12 +19,15 @@ class PlayerDeathListener(private val configProvider: () -> HeadConfig) : Listen
     fun onDeath(event: PlayerDeathEvent) {
         val victim = event.entity
         val killer: Player? = victim.killer
-        val shouldDrop = HeadDropDecision.shouldDrop(
+        // Interim bridge: with looting disabled (default) dropChance is 1.0/0.0, matching the old
+        // boolean. Task 3 replaces this with the real Looting read + RNG roll.
+        val chance = HeadDropDecision.dropChance(
             config = configProvider(),
             killerIsPlayer = killer != null,
             killerIsSelf = killer != null && killer == victim,
+            lootingLevel = 0,
         )
-        if (!shouldDrop) return
+        if (chance < 1.0) return
 
         val head = createHead(victim)
         // Mirror the mod: head joins the death drops by default; with keepInventory it stays on the player.

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/PlayerDeathListener.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/PlayerDeathListener.kt
@@ -1,39 +1,54 @@
 package online.slavok.heads.plugin
 
 import org.bukkit.Material
+import org.bukkit.enchantments.Enchantment
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.entity.PlayerDeathEvent
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.SkullMeta
+import java.util.Random
 
 /**
  * Bukkit counterpart of the mod's ServerPlayer.die mixin. `victim.killer` already resolves a
- * projectile to its shooting player (or null), mirroring the mod's DamageSource.getAttacker().
+ * projectile to its shooting player (or null). The killer's main-hand Looting level drives the
+ * per-level drop chance; `random` is injectable so tests are deterministic.
  */
-class PlayerDeathListener(private val configProvider: () -> HeadConfig) : Listener {
+class PlayerDeathListener(
+    private val configProvider: () -> HeadConfig,
+    private val random: Random = Random(),
+) : Listener {
 
     // PlayerDeathEvent is not Cancellable, so no ignoreCancelled here.
     @EventHandler
     fun onDeath(event: PlayerDeathEvent) {
         val victim = event.entity
         val killer: Player? = victim.killer
-        // Interim bridge: with looting disabled (default) dropChance is 1.0/0.0, matching the old
-        // boolean. Task 3 replaces this with the real Looting read + RNG roll.
+        val lootingLevel = if (killer != null) lootingLevel(killer.inventory.itemInMainHand) else 0
         val chance = HeadDropDecision.dropChance(
             config = configProvider(),
             killerIsPlayer = killer != null,
             killerIsSelf = killer != null && killer == victim,
-            lootingLevel = 0,
+            lootingLevel = lootingLevel,
         )
-        if (chance < 1.0) return
+        if (!rolls(chance)) return
 
         val head = createHead(victim)
         // Mirror the mod: head joins the death drops by default; with keepInventory it stays on the player.
         if (event.keepInventory) victim.inventory.addItem(head)
         else event.drops.add(head)
     }
+
+    private fun rolls(chance: Double): Boolean = when {
+        chance <= 0.0 -> false
+        chance >= 1.0 -> true
+        else -> random.nextDouble() < chance
+    }
+
+    /** Looting level of [weapon]; 0 for AIR or an un-enchanted item. */
+    private fun lootingLevel(weapon: ItemStack): Int =
+        weapon.getEnchantmentLevel(Enchantment.LOOTING)
 
     private fun createHead(owner: Player): ItemStack {
         val head = ItemStack(Material.PLAYER_HEAD)

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/SimplePlayerHeadsPlugin.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/SimplePlayerHeadsPlugin.kt
@@ -19,9 +19,9 @@ open class SimplePlayerHeadsPlugin : JavaPlugin() {
             otherDeaths = c.getBoolean("otherDeaths", true),
             playerKillLooting = PlayerKillLooting(
                 enabled = c.getBoolean("playerKillLooting.enabled", false),
-                noLooting = c.getDouble("playerKillLooting.noLooting", 1.0),
-                looting1 = c.getDouble("playerKillLooting.looting1", 1.0),
-                looting2 = c.getDouble("playerKillLooting.looting2", 1.0),
+                noLooting = c.getDouble("playerKillLooting.noLooting", 0.0),
+                looting1 = c.getDouble("playerKillLooting.looting1", 0.33),
+                looting2 = c.getDouble("playerKillLooting.looting2", 0.67),
                 looting3 = c.getDouble("playerKillLooting.looting3", 1.0),
             ),
         )

--- a/plugin/src/main/kotlin/online/slavok/heads/plugin/SimplePlayerHeadsPlugin.kt
+++ b/plugin/src/main/kotlin/online/slavok/heads/plugin/SimplePlayerHeadsPlugin.kt
@@ -17,6 +17,13 @@ open class SimplePlayerHeadsPlugin : JavaPlugin() {
             selfKill = c.getBoolean("selfKill", true),
             playerKill = c.getBoolean("playerKill", true),
             otherDeaths = c.getBoolean("otherDeaths", true),
+            playerKillLooting = PlayerKillLooting(
+                enabled = c.getBoolean("playerKillLooting.enabled", false),
+                noLooting = c.getDouble("playerKillLooting.noLooting", 1.0),
+                looting1 = c.getDouble("playerKillLooting.looting1", 1.0),
+                looting2 = c.getDouble("playerKillLooting.looting2", 1.0),
+                looting3 = c.getDouble("playerKillLooting.looting3", 1.0),
+            ),
         )
     }
 }

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -4,3 +4,13 @@ selfKill: true
 playerKill: true
 # If true, player will get his head after all other deaths
 otherDeaths: true
+# Per-Looting-level drop chance for kills by another player.
+# Only used when playerKill is true (playerKill=false never drops a head on a player kill).
+playerKillLooting:
+  # Master switch: false = ignore Looting, use the playerKill flag as before.
+  enabled: false
+  # Drop chance 0.0-1.0 by the killer's Looting level (Looting above III uses looting3).
+  noLooting: 1.0
+  looting1: 1.0
+  looting2: 1.0
+  looting3: 1.0

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -10,7 +10,7 @@ playerKillLooting:
   # Master switch: false = ignore Looting, use the playerKill flag as before.
   enabled: false
   # Drop chance 0.0-1.0 by the killer's Looting level (Looting above III uses looting3).
-  noLooting: 1.0
-  looting1: 1.0
-  looting2: 1.0
+  noLooting: 0.0
+  looting1: 0.33
+  looting2: 0.67
   looting3: 1.0

--- a/plugin/src/test/kotlin/online/slavok/heads/plugin/HeadDropDecisionTest.kt
+++ b/plugin/src/test/kotlin/online/slavok/heads/plugin/HeadDropDecisionTest.kt
@@ -1,34 +1,70 @@
 package online.slavok.heads.plugin
 
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class HeadDropDecisionTest {
 
-    @Test
-    fun `self kill follows selfKill flag`() {
-        assertTrue(HeadDropDecision.shouldDrop(HeadConfig(selfKill = true), killerIsPlayer = true, killerIsSelf = true))
-        assertFalse(HeadDropDecision.shouldDrop(HeadConfig(selfKill = false), killerIsPlayer = true, killerIsSelf = true))
-    }
+    private fun chance(config: HeadConfig, player: Boolean, self: Boolean, looting: Int = 0) =
+        HeadDropDecision.dropChance(config, player, self, looting)
 
     @Test
-    fun `player kill follows playerKill flag`() {
-        assertTrue(HeadDropDecision.shouldDrop(HeadConfig(playerKill = true), killerIsPlayer = true, killerIsSelf = false))
-        assertFalse(HeadDropDecision.shouldDrop(HeadConfig(playerKill = false), killerIsPlayer = true, killerIsSelf = false))
+    fun `self kill follows selfKill flag`() {
+        assertEquals(1.0, chance(HeadConfig(selfKill = true), player = true, self = true))
+        assertEquals(0.0, chance(HeadConfig(selfKill = false), player = true, self = true))
     }
 
     @Test
     fun `other death follows otherDeaths flag`() {
-        assertTrue(HeadDropDecision.shouldDrop(HeadConfig(otherDeaths = true), killerIsPlayer = false, killerIsSelf = false))
-        assertFalse(HeadDropDecision.shouldDrop(HeadConfig(otherDeaths = false), killerIsPlayer = false, killerIsSelf = false))
+        assertEquals(1.0, chance(HeadConfig(otherDeaths = true), player = false, self = false))
+        assertEquals(0.0, chance(HeadConfig(otherDeaths = false), player = false, self = false))
     }
 
     @Test
-    fun `self kill flag is independent of the other flags`() {
-        val config = HeadConfig(selfKill = true, playerKill = false, otherDeaths = false)
-        assertTrue(HeadDropDecision.shouldDrop(config, killerIsPlayer = true, killerIsSelf = true))
-        assertFalse(HeadDropDecision.shouldDrop(config, killerIsPlayer = true, killerIsSelf = false))
-        assertFalse(HeadDropDecision.shouldDrop(config, killerIsPlayer = false, killerIsSelf = false))
+    fun `player kill with looting disabled follows playerKill flag`() {
+        assertEquals(1.0, chance(HeadConfig(playerKill = true), player = true, self = false))
+        assertEquals(0.0, chance(HeadConfig(playerKill = false), player = true, self = false))
+    }
+
+    @Test
+    fun `playerKill false overrides looting even when enabled`() {
+        val config = HeadConfig(
+            playerKill = false,
+            playerKillLooting = PlayerKillLooting(enabled = true, noLooting = 1.0, looting3 = 1.0),
+        )
+        assertEquals(0.0, chance(config, player = true, self = false, looting = 3))
+    }
+
+    @Test
+    fun `enabled looting selects the bucket by level`() {
+        val config = HeadConfig(
+            playerKill = true,
+            playerKillLooting = PlayerKillLooting(
+                enabled = true, noLooting = 0.0, looting1 = 0.25, looting2 = 0.5, looting3 = 1.0,
+            ),
+        )
+        assertEquals(0.0, chance(config, player = true, self = false, looting = 0))
+        assertEquals(0.25, chance(config, player = true, self = false, looting = 1))
+        assertEquals(0.5, chance(config, player = true, self = false, looting = 2))
+        assertEquals(1.0, chance(config, player = true, self = false, looting = 3))
+    }
+
+    @Test
+    fun `looting above three clamps to looting3`() {
+        val config = HeadConfig(
+            playerKill = true,
+            playerKillLooting = PlayerKillLooting(enabled = true, looting3 = 0.7),
+        )
+        assertEquals(0.7, chance(config, player = true, self = false, looting = 5))
+    }
+
+    @Test
+    fun `enabled looting does not affect self kill or other deaths`() {
+        val config = HeadConfig(
+            selfKill = true, otherDeaths = true,
+            playerKillLooting = PlayerKillLooting(enabled = true, noLooting = 0.0),
+        )
+        assertEquals(1.0, chance(config, player = true, self = true, looting = 0))
+        assertEquals(1.0, chance(config, player = false, self = false, looting = 0))
     }
 }

--- a/plugin/src/test/kotlin/online/slavok/heads/plugin/PlayerDeathListenerTest.kt
+++ b/plugin/src/test/kotlin/online/slavok/heads/plugin/PlayerDeathListenerTest.kt
@@ -1,0 +1,106 @@
+package online.slavok.heads.plugin
+
+import org.bukkit.Material
+import org.bukkit.damage.DamageSource
+import org.bukkit.damage.DamageType
+import org.bukkit.enchantments.Enchantment
+import org.bukkit.entity.Player
+import org.bukkit.event.entity.PlayerDeathEvent
+import org.bukkit.inventory.ItemStack
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import org.mockbukkit.mockbukkit.entity.PlayerMock
+import java.util.Random
+
+class PlayerDeathListenerTest {
+    private lateinit var server: ServerMock
+
+    @BeforeEach fun setUp() { server = MockBukkit.mock() }
+    @AfterEach fun tearDown() { MockBukkit.unmock() }
+
+    /** Builds a PlayerDeathEvent for `victim`, with `killer` as its killer, no keepInventory. */
+    private fun deathEvent(victim: PlayerMock, killer: Player?): PlayerDeathEvent {
+        victim.killer = killer
+        val source = DamageSource.builder(DamageType.GENERIC).build()
+        return PlayerDeathEvent(victim, source, mutableListOf<ItemStack>(), 0, victim.name)
+    }
+
+    private fun heads(drops: List<ItemStack>) = drops.count { it.type == Material.PLAYER_HEAD }
+
+    @Test
+    fun `looting-II weapon uses looting2 bucket and rolls a drop`() {
+        val config = HeadConfig(
+            playerKill = true,
+            playerKillLooting = PlayerKillLooting(enabled = true, noLooting = 0.0, looting2 = 0.5),
+        )
+        // random.nextDouble() = 0.4 < 0.5 -> drop
+        val listener = PlayerDeathListener({ config }, seededDouble(0.4))
+        val victim = server.addPlayer()
+        val killer = server.addPlayer()
+        val sword = ItemStack(Material.DIAMOND_SWORD).apply { addUnsafeEnchantment(Enchantment.LOOTING, 2) }
+        killer.inventory.setItemInMainHand(sword)
+
+        val event = deathEvent(victim, killer)
+        listener.onDeath(event)
+
+        assertEquals(1, heads(event.drops))
+    }
+
+    @Test
+    fun `looting-II weapon skips drop when roll exceeds chance`() {
+        val config = HeadConfig(
+            playerKill = true,
+            playerKillLooting = PlayerKillLooting(enabled = true, noLooting = 0.0, looting2 = 0.5),
+        )
+        // random.nextDouble() = 0.6 !< 0.5 -> no drop
+        val listener = PlayerDeathListener({ config }, seededDouble(0.6))
+        val victim = server.addPlayer()
+        val killer = server.addPlayer()
+        val sword = ItemStack(Material.DIAMOND_SWORD).apply { addUnsafeEnchantment(Enchantment.LOOTING, 2) }
+        killer.inventory.setItemInMainHand(sword)
+
+        val event = deathEvent(victim, killer)
+        listener.onDeath(event)
+
+        assertEquals(0, heads(event.drops))
+    }
+
+    @Test
+    fun `no looting with noLooting zero drops nothing`() {
+        val config = HeadConfig(
+            playerKill = true,
+            playerKillLooting = PlayerKillLooting(enabled = true, noLooting = 0.0),
+        )
+        val listener = PlayerDeathListener({ config }, seededDouble(0.0))
+        val victim = server.addPlayer()
+        val killer = server.addPlayer()
+        killer.inventory.setItemInMainHand(ItemStack(Material.STICK))
+
+        val event = deathEvent(victim, killer)
+        listener.onDeath(event)
+
+        assertEquals(0, heads(event.drops))
+    }
+
+    @Test
+    fun `default config still drops on every player kill`() {
+        val listener = PlayerDeathListener({ HeadConfig() }, seededDouble(0.99))
+        val victim = server.addPlayer()
+        val killer = server.addPlayer()
+        killer.inventory.setItemInMainHand(ItemStack(Material.STICK))
+
+        val event = deathEvent(victim, killer)
+        listener.onDeath(event)
+
+        assertEquals(1, heads(event.drops))
+    }
+
+    /** A Random whose nextDouble() always returns `value`. */
+    private fun seededDouble(value: Double) = object : Random() {
+        override fun nextDouble() = value
+    }
+}

--- a/plugin/src/test/kotlin/online/slavok/heads/plugin/PluginConfigTest.kt
+++ b/plugin/src/test/kotlin/online/slavok/heads/plugin/PluginConfigTest.kt
@@ -1,0 +1,22 @@
+package online.slavok.heads.plugin
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+class PluginConfigTest {
+    @Test
+    fun `looting defaults preserve current behavior`() {
+        val looting = PlayerKillLooting()
+        assertFalse(looting.enabled)
+        assertEquals(1.0, looting.noLooting)
+        assertEquals(1.0, looting.looting1)
+        assertEquals(1.0, looting.looting2)
+        assertEquals(1.0, looting.looting3)
+    }
+
+    @Test
+    fun `head config nests looting with a default`() {
+        assertEquals(PlayerKillLooting(), HeadConfig().playerKillLooting)
+    }
+}

--- a/plugin/src/test/kotlin/online/slavok/heads/plugin/PluginConfigTest.kt
+++ b/plugin/src/test/kotlin/online/slavok/heads/plugin/PluginConfigTest.kt
@@ -6,12 +6,14 @@ import org.junit.jupiter.api.Test
 
 class PluginConfigTest {
     @Test
-    fun `looting defaults preserve current behavior`() {
+    fun `looting defaults - disabled with a graduated chance curve`() {
+        // Disabled by default -> behavior unchanged (chances are ignored until enabled).
+        // The chance defaults are a suggested curve for when a server flips enabled=true.
         val looting = PlayerKillLooting()
         assertFalse(looting.enabled)
-        assertEquals(1.0, looting.noLooting)
-        assertEquals(1.0, looting.looting1)
-        assertEquals(1.0, looting.looting2)
+        assertEquals(0.0, looting.noLooting)
+        assertEquals(0.33, looting.looting1)
+        assertEquals(0.67, looting.looting2)
         assertEquals(1.0, looting.looting3)
     }
 

--- a/src/gametest/java/online/slavok/heads/gametest/ConfigGameTest.java
+++ b/src/gametest/java/online/slavok/heads/gametest/ConfigGameTest.java
@@ -1,0 +1,69 @@
+package online.slavok.heads.gametest;
+
+import online.slavok.heads.config.ConfigManager;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+//? if >=1.21 {
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+//?} else {
+/*import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.test.GameTest;*/
+//?}
+//? if >=1.22 {
+/*import net.minecraft.gametest.framework.GameTestHelper;*/
+//?} else {
+import net.minecraft.test.TestContext;
+//?}
+
+/**
+ * Proves the config round-trips through tomlkt with the new playerKillLooting section on every
+ * supported Minecraft version: constructing a ConfigManager on a fresh file writes the default
+ * config, and that TOML must carry the section with backward-compatible defaults (enabled off).
+ * Driving it through ConfigManager exercises the real encode path the mod uses at startup.
+ */
+//? if >=1.21 {
+public class ConfigGameTest {
+//?} else {
+/*public class ConfigGameTest implements FabricGameTest {*/
+//?}
+
+    //? if >=1.21 {
+    @GameTest
+    //?} elif >=1.19 {
+    /*@GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)*/
+    //?} else {
+    /*@GameTest(structureName = FabricGameTest.EMPTY_STRUCTURE)*/
+    //?}
+    //? if >=1.22 {
+    /*public void lootingSectionRoundTrips(GameTestHelper context) {
+        run();
+        context.succeed();
+    }*/
+    //?} else {
+    public void lootingSectionRoundTrips(TestContext context) {
+        run();
+        context.complete();
+    }
+    //?}
+
+    private static void run() {
+        try {
+            File tmp = File.createTempFile("sph-config-test", ".toml");
+            // Delete so ConfigManager sees a missing file and writes the defaults itself.
+            if (!tmp.delete()) throw new RuntimeException("could not clear temp config file");
+            new ConfigManager(tmp);
+            String toml = Files.readString(tmp.toPath());
+            tmp.delete();
+
+            if (!toml.contains("playerKillLooting"))
+                throw new RuntimeException("config TOML is missing the playerKillLooting section:\n" + toml);
+            if (!toml.contains("enabled = false"))
+                throw new RuntimeException("playerKillLooting.enabled must default to false:\n" + toml);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/gametest/java/online/slavok/heads/gametest/HeadDropGameTest.java
+++ b/src/gametest/java/online/slavok/heads/gametest/HeadDropGameTest.java
@@ -24,6 +24,22 @@ import net.minecraft.item.Items;
 //? if >=1.20.5 && <1.22 {
 import net.minecraft.component.DataComponentTypes;
 //?}
+// Looting enchant application for the lootingLevel test (mirrors the version-split enchant API).
+//? if <1.22 {
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.enchantment.Enchantments;
+//?} else {
+/*import net.minecraft.world.level.Level;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.Enchantments;*/
+//?}
+//? if >=1.21 && <1.22 {
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.enchantment.Enchantment;
+//?}
 
 /**
  * Verifies that the version-specific head creation actually produces a profile-bearing
@@ -109,6 +125,58 @@ public class HeadDropGameTest {
 
     private static void expect(double want, double got) {
         if (want != got) throw new RuntimeException("dropChance expected " + want + " got " + got);
+    }
+
+    //? if >=1.21 {
+    @GameTest
+    //?} elif >=1.19 {
+    /*@GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)*/
+    //?} else {
+    /*@GameTest(structureName = FabricGameTest.EMPTY_STRUCTURE)*/
+    //?}
+    //? if >=1.22 {
+    /*public void lootingLevelReadsEnchantment(GameTestHelper context) {
+        Level world = context.getLevel();
+        ItemStack sword = lootingSword(world);
+        if (PlayerDeathEvent.lootingLevel(sword, world) != 2)
+            throw new RuntimeException("expected Looting 2, got " + PlayerDeathEvent.lootingLevel(sword, world));
+        if (PlayerDeathEvent.lootingLevel(new ItemStack(Items.STICK), world) != 0)
+            throw new RuntimeException("control failed: a plain item reported Looting");
+        context.succeed();
+    }*/
+    //?} else {
+    public void lootingLevelReadsEnchantment(TestContext context) {
+        ServerWorld world = context.getWorld();
+        ItemStack sword = lootingSword(world);
+        if (PlayerDeathEvent.lootingLevel(sword, world) != 2)
+            throw new RuntimeException("expected Looting 2, got " + PlayerDeathEvent.lootingLevel(sword, world));
+        if (PlayerDeathEvent.lootingLevel(new ItemStack(Items.STICK), world) != 0)
+            throw new RuntimeException("control failed: a plain item reported Looting");
+        context.complete();
+    }
+    //?}
+
+    /** Builds a diamond sword enchanted with Looting II, using the version-specific enchant API. */
+    private static ItemStack lootingSword(Object rawWorld) {
+        //? if >=1.22 {
+        /*Level world = (Level) rawWorld;
+        ItemStack sword = new ItemStack(Items.DIAMOND_SWORD);
+        Holder<Enchantment> looting = world.registryAccess()
+                .lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(Enchantments.LOOTING);
+        sword.enchant(looting, 2);
+        return sword;
+        *///?} elif >=1.21 {
+        ServerWorld world = (ServerWorld) rawWorld;
+        ItemStack sword = new ItemStack(Items.DIAMOND_SWORD);
+        RegistryEntry<Enchantment> looting = world.getRegistryManager()
+                .getOrThrow(RegistryKeys.ENCHANTMENT).getOrThrow(Enchantments.LOOTING);
+        sword.addEnchantment(looting, 2);
+        return sword;
+        //?} else {
+        /*ItemStack sword = new ItemStack(Items.DIAMOND_SWORD);
+        sword.addEnchantment(Enchantments.LOOTING, 2);
+        return sword;*/
+        //?}
     }
 
     private static boolean hasProfile(ItemStack head) {

--- a/src/gametest/java/online/slavok/heads/gametest/HeadDropGameTest.java
+++ b/src/gametest/java/online/slavok/heads/gametest/HeadDropGameTest.java
@@ -65,6 +65,52 @@ public class HeadDropGameTest {
     }
     //?}
 
+    //? if >=1.21 {
+    @GameTest
+    //?} elif >=1.19 {
+    /*@GameTest(templateName = FabricGameTest.EMPTY_STRUCTURE)*/
+    //?} else {
+    /*@GameTest(structureName = FabricGameTest.EMPTY_STRUCTURE)*/
+    //?}
+    //? if >=1.22 {
+    /*public void dropChanceBucketsByLooting(GameTestHelper context) {
+        checkDropChance();
+        context.succeed();
+    }*/
+    //?} else {
+    public void dropChanceBucketsByLooting(TestContext context) {
+        checkDropChance();
+        context.complete();
+    }
+    //?}
+
+    private static void checkDropChance() {
+        online.slavok.heads.config.PlayerKillLooting looting =
+                new online.slavok.heads.config.PlayerKillLooting(true, 0.0, 0.25, 0.5, 1.0);
+        online.slavok.heads.config.Config config =
+                new online.slavok.heads.config.Config(true, true, true, looting);
+
+        // playerKill=false overrides looting.
+        online.slavok.heads.config.Config gated =
+                new online.slavok.heads.config.Config(true, false, true, looting);
+        expect(0.0, PlayerDeathEvent.dropChance(gated, true, false, 3));
+
+        // Buckets by level + clamp above III.
+        expect(0.0, PlayerDeathEvent.dropChance(config, true, false, 0));
+        expect(0.25, PlayerDeathEvent.dropChance(config, true, false, 1));
+        expect(0.5, PlayerDeathEvent.dropChance(config, true, false, 2));
+        expect(1.0, PlayerDeathEvent.dropChance(config, true, false, 3));
+        expect(1.0, PlayerDeathEvent.dropChance(config, true, false, 7));
+
+        // Self kill / other deaths ignore looting.
+        expect(1.0, PlayerDeathEvent.dropChance(config, true, true, 0));
+        expect(1.0, PlayerDeathEvent.dropChance(config, false, false, 0));
+    }
+
+    private static void expect(double want, double got) {
+        if (want != got) throw new RuntimeException("dropChance expected " + want + " got " + got);
+    }
+
     private static boolean hasProfile(ItemStack head) {
         //? if <1.20.5 {
         /*return head.getNbt() != null && head.getNbt().contains("SkullOwner");*/

--- a/src/gametest/resources/fabric.mod.json
+++ b/src/gametest/resources/fabric.mod.json
@@ -6,7 +6,8 @@
 	"environment": "*",
 	"entrypoints": {
 		"fabric-gametest": [
-			"online.slavok.heads.gametest.HeadDropGameTest"
+			"online.slavok.heads.gametest.HeadDropGameTest",
+			"online.slavok.heads.gametest.ConfigGameTest"
 		]
 	},
 	"depends": {

--- a/src/main/kotlin/online/slavok/heads/ModMenuIntegration.kt
+++ b/src/main/kotlin/online/slavok/heads/ModMenuIntegration.kt
@@ -4,6 +4,7 @@ import com.terraformersmc.modmenu.api.ConfigScreenFactory
 import com.terraformersmc.modmenu.api.ModMenuApi
 import me.shedaniel.clothconfig2.api.ConfigBuilder
 import online.slavok.heads.config.Config
+import online.slavok.heads.config.PlayerKillLooting
 //? if >=1.22 {
 /*import net.minecraft.network.chat.Component
 *///?} else {
@@ -49,8 +50,51 @@ class ModMenuIntegration : ModMenuApi {
                 .build(),
         )
 
+        val looting = config.playerKillLooting
+        var lootingEnabled = looting.enabled
+        var noLooting = looting.noLooting
+        var looting1 = looting.looting1
+        var looting2 = looting.looting2
+        var looting3 = looting.looting3
+
+        category.addEntry(
+            entries.startBooleanToggle(literal("playerKillLooting.enabled"), looting.enabled)
+                .setDefaultValue(false)
+                .setSaveConsumer { lootingEnabled = it }
+                .build(),
+        )
+        category.addEntry(
+            entries.startDoubleField(literal("playerKillLooting.noLooting"), looting.noLooting)
+                .setMin(0.0).setMax(1.0).setDefaultValue(1.0)
+                .setSaveConsumer { noLooting = it }
+                .build(),
+        )
+        category.addEntry(
+            entries.startDoubleField(literal("playerKillLooting.looting1"), looting.looting1)
+                .setMin(0.0).setMax(1.0).setDefaultValue(1.0)
+                .setSaveConsumer { looting1 = it }
+                .build(),
+        )
+        category.addEntry(
+            entries.startDoubleField(literal("playerKillLooting.looting2"), looting.looting2)
+                .setMin(0.0).setMax(1.0).setDefaultValue(1.0)
+                .setSaveConsumer { looting2 = it }
+                .build(),
+        )
+        category.addEntry(
+            entries.startDoubleField(literal("playerKillLooting.looting3"), looting.looting3)
+                .setMin(0.0).setMax(1.0).setDefaultValue(1.0)
+                .setSaveConsumer { looting3 = it }
+                .build(),
+        )
+
         builder.setSavingRunnable {
-            SimplePlayerHeads.configManager.save(Config(selfKill, playerKill, otherDeaths))
+            SimplePlayerHeads.configManager.save(
+                Config(
+                    selfKill, playerKill, otherDeaths,
+                    PlayerKillLooting(lootingEnabled, noLooting, looting1, looting2, looting3),
+                ),
+            )
         }
         builder.build()
     }

--- a/src/main/kotlin/online/slavok/heads/config/Config.kt
+++ b/src/main/kotlin/online/slavok/heads/config/Config.kt
@@ -8,11 +8,11 @@ data class PlayerKillLooting(
     @TomlComment("Enable per-Looting-level drop chance for kills by another player")
     val enabled: Boolean = false,
     @TomlComment("Drop chance (0.0-1.0) when the killer's weapon has no Looting")
-    val noLooting: Double = 1.0,
+    val noLooting: Double = 0.0,
     @TomlComment("Drop chance with Looting I")
-    val looting1: Double = 1.0,
+    val looting1: Double = 0.33,
     @TomlComment("Drop chance with Looting II")
-    val looting2: Double = 1.0,
+    val looting2: Double = 0.67,
     @TomlComment("Drop chance with Looting III (and above)")
     val looting3: Double = 1.0,
 )

--- a/src/main/kotlin/online/slavok/heads/config/Config.kt
+++ b/src/main/kotlin/online/slavok/heads/config/Config.kt
@@ -4,11 +4,27 @@ import kotlinx.serialization.Serializable
 import net.peanuuutz.tomlkt.TomlComment
 
 @Serializable
+data class PlayerKillLooting(
+    @TomlComment("Enable per-Looting-level drop chance for kills by another player")
+    val enabled: Boolean = false,
+    @TomlComment("Drop chance (0.0-1.0) when the killer's weapon has no Looting")
+    val noLooting: Double = 1.0,
+    @TomlComment("Drop chance with Looting I")
+    val looting1: Double = 1.0,
+    @TomlComment("Drop chance with Looting II")
+    val looting2: Double = 1.0,
+    @TomlComment("Drop chance with Looting III (and above)")
+    val looting3: Double = 1.0,
+)
+
+@Serializable
 data class Config(
     @TomlComment("If true, player will get his head after self kill")
     val selfKill: Boolean = true,
     @TomlComment("If true, player will get his head after kill by another player")
     val playerKill: Boolean = true,
     @TomlComment("If true, player will get his head after all other deaths")
-    val otherDeaths: Boolean = true
+    val otherDeaths: Boolean = true,
+    @TomlComment("Only used when playerKill is true; playerKill=false never drops on a player kill")
+    val playerKillLooting: PlayerKillLooting = PlayerKillLooting()
 )

--- a/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
+++ b/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
@@ -23,14 +23,28 @@ import net.minecraft.component.type.ProfileComponent
 /*import net.minecraft.core.component.DataComponents
 import net.minecraft.world.item.component.ResolvableProfile
 *///?}
+// Looting enchantment access: static object <1.20.5, registry entry 1.20.5+, Mojang names 1.22+.
+//? if <1.22 {
+import net.minecraft.enchantment.EnchantmentHelper
+import net.minecraft.enchantment.Enchantments
+//?} else {
+/*import net.minecraft.world.item.enchantment.EnchantmentHelper
+import net.minecraft.world.item.enchantment.Enchantments
+import net.minecraft.core.registries.Registries*/
+//?}
+//? if >=1.21 && <1.22 {
+import net.minecraft.registry.RegistryKeys
+//?}
 
-// Player and inventory classes were renamed in the unobfuscated (26+) mappings.
+// Player, inventory and world classes were renamed in the unobfuscated (26+) mappings.
 //? if <1.22 {
 private typealias PlayerInv = net.minecraft.entity.player.PlayerInventory
 private typealias PlayerType = net.minecraft.entity.player.PlayerEntity
+private typealias WorldType = net.minecraft.world.World
 //?} else {
 /*private typealias PlayerInv = net.minecraft.world.entity.player.Inventory
-private typealias PlayerType = net.minecraft.world.entity.player.Player*/
+private typealias PlayerType = net.minecraft.world.entity.player.Player
+private typealias WorldType = net.minecraft.world.level.Level*/
 //?}
 
 object PlayerDeathEvent {
@@ -77,6 +91,22 @@ object PlayerDeathEvent {
             2 -> looting.looting2
             else -> looting.looting3
         }
+    }
+
+    /** Looting level of [weapon]; 0 if unenchanted. [world] supplies the enchantment registry (1.20.5+). */
+    @JvmStatic
+    fun lootingLevel(weapon: ItemStack, world: WorldType): Int {
+        // <1.21: Enchantments.LOOTING is the Enchantment value. 1.21+: it is a RegistryKey, so
+        // resolve it to a RegistryEntry via the world registry. 1.22+: Mojang names + Holder.
+        //? if <1.21 {
+        /*return EnchantmentHelper.getLevel(Enchantments.LOOTING, weapon)
+        *///?} elif <1.22 {
+        val entry = world.registryManager.getOrThrow(RegistryKeys.ENCHANTMENT).getOrThrow(Enchantments.LOOTING)
+        return EnchantmentHelper.getLevel(entry, weapon)
+        //?} else {
+        /*val holder = world.registryAccess().lookupOrThrow(Registries.ENCHANTMENT).getOrThrow(Enchantments.LOOTING)
+        return EnchantmentHelper.getItemEnchantmentLevel(holder, weapon)
+        *///?}
     }
 
     private fun addHead(gameProfile: GameProfile, inventory: PlayerInv) {

--- a/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
+++ b/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
@@ -3,6 +3,7 @@ package online.slavok.heads.events
 import com.mojang.authlib.GameProfile
 import online.slavok.heads.ModBehavior
 import online.slavok.heads.SimplePlayerHeads
+import online.slavok.heads.config.Config
 //? if <1.22 {
 import net.minecraft.entity.damage.DamageSource
 import net.minecraft.item.ItemStack
@@ -36,22 +37,45 @@ object PlayerDeathEvent {
     @JvmStatic
     fun onPlayerDeath(gameProfile: GameProfile, inventory: PlayerInv, damageSource: DamageSource) {
         if (!ModBehavior.active) return
-        if (shouldDropHead(gameProfile, damageSource)) {
-            addHead(gameProfile, inventory)
-        }
-    }
-
-    private fun shouldDropHead(gameProfile: GameProfile, damageSource: DamageSource): Boolean {
-        val config = SimplePlayerHeads.configManager.config
         //? if >=1.22 {
         /*val attacker = damageSource.entity*/
         //?} else {
         val attacker = damageSource.attacker
         //?}
-        return when {
-            attacker is PlayerType && attacker.gameProfile == gameProfile -> config.selfKill
-            attacker is PlayerType -> config.playerKill
-            else -> config.otherDeaths
+        val killerIsPlayer = attacker is PlayerType
+        val killerIsSelf = attacker is PlayerType && attacker.gameProfile == gameProfile
+        // Interim: real Looting level + RNG roll land in the wire-up task. With looting disabled
+        // (default) dropChance is 1.0/0.0, matching the old boolean behavior.
+        val chance = dropChance(SimplePlayerHeads.configManager.config, killerIsPlayer, killerIsSelf, 0)
+        if (chance >= 1.0) addHead(gameProfile, inventory)
+    }
+
+    /**
+     * Pure decision mirrored from the plugin's HeadDropDecision: the head's drop probability
+     * [0.0, 1.0] given how the victim died and the killer's Looting level. `killerIsSelf` and
+     * `lootingLevel` are only meaningful when `killerIsPlayer`. Public so gametests can assert it.
+     */
+    @JvmStatic
+    fun dropChance(
+        config: Config,
+        killerIsPlayer: Boolean,
+        killerIsSelf: Boolean,
+        lootingLevel: Int,
+    ): Double = when {
+        killerIsPlayer && killerIsSelf -> if (config.selfKill) 1.0 else 0.0
+        killerIsPlayer -> playerKillChance(config, lootingLevel)
+        else -> if (config.otherDeaths) 1.0 else 0.0
+    }
+
+    private fun playerKillChance(config: Config, lootingLevel: Int): Double {
+        if (!config.playerKill) return 0.0
+        val looting = config.playerKillLooting
+        if (!looting.enabled) return 1.0
+        return when (lootingLevel.coerceIn(0, 3)) {
+            0 -> looting.noLooting
+            1 -> looting.looting1
+            2 -> looting.looting2
+            else -> looting.looting3
         }
     }
 

--- a/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
+++ b/src/main/kotlin/online/slavok/heads/events/PlayerDeathEvent.kt
@@ -58,10 +58,34 @@ object PlayerDeathEvent {
         //?}
         val killerIsPlayer = attacker is PlayerType
         val killerIsSelf = attacker is PlayerType && attacker.gameProfile == gameProfile
-        // Interim: real Looting level + RNG roll land in the wire-up task. With looting disabled
-        // (default) dropChance is 1.0/0.0, matching the old boolean behavior.
-        val chance = dropChance(SimplePlayerHeads.configManager.config, killerIsPlayer, killerIsSelf, 0)
-        if (chance >= 1.0) addHead(gameProfile, inventory)
+        val lootingLevel = if (attacker is PlayerType) lootingLevelOf(attacker) else 0
+        val chance = dropChance(
+            SimplePlayerHeads.configManager.config, killerIsPlayer, killerIsSelf, lootingLevel,
+        )
+        if (rolls(chance, attacker)) addHead(gameProfile, inventory)
+    }
+
+    /** Looting level of the killer's main-hand weapon (mappings rename the accessors at 1.22). */
+    private fun lootingLevelOf(attacker: PlayerType): Int {
+        //? if <1.22 {
+        val weapon = attacker.mainHandStack
+        val world = attacker.world
+        //?} else {
+        /*val weapon = attacker.mainHandItem
+        val world = attacker.level()*/
+        //?}
+        return lootingLevel(weapon, world)
+    }
+
+    /**
+     * Whether the head drops for [chance]. A fractional chance only arises on the player-kill path
+     * (looting enabled), where [attacker] is a player and supplies the RNG; 1.0/0.0 short-circuit.
+     */
+    private fun rolls(chance: Double, attacker: Any?): Boolean = when {
+        chance <= 0.0 -> false
+        chance >= 1.0 -> true
+        attacker is PlayerType -> attacker.random.nextDouble() < chance
+        else -> false
     }
 
     /**


### PR DESCRIPTION
Closes #1.

Adds an opt-in setting so a player-kill head drop can depend on the killer's **Looting** enchantment, with a **separately configurable drop chance per Looting level** (none / I / II / III). Shipped to both the Fabric mod (MC 1.18.1–26.2) and the Bukkit plugin.

## Config (both targets)

```toml
[playerKillLooting]
enabled = false   # master switch for the feature
noLooting = 1.0   # drop chance 0.0–1.0 when the killer has no Looting
looting1 = 1.0    # Looting I
looting2 = 1.0    # Looting II
looting3 = 1.0    # Looting III (and above — clamped)
```

Same section in the plugin's `config.yml`.

## Semantics

- `enabled=false` (default) + all chances `1.0` → **behavior identical to today**; old config files keep working.
- Applies **only to the "killed by another player" path**. `selfKill` / `otherDeaths` stay plain booleans.
- `playerKill` is the master gate (**AND**): `playerKill=false` never drops a head on a player kill, even with Looting.
- Looting level > III clamps to `looting3`.
- Weapon = killer's main-hand item at death time (projectile kills resolve to the shooter; a bow → `noLooting` bucket).

## Implementation

- Pure `dropChance(...) : Double` mirrored in mod (`PlayerDeathEvent`) and plugin (`HeadDropDecision`); RNG rolled at the edge with an injectable random → deterministic tests.
- Mod Looting extraction is Stonecutter version-split across three enchant-API eras:
  - `<1.21`: `EnchantmentHelper.getLevel(Enchantments.LOOTING, stack)` (value)
  - `>=1.21 <1.22`: registry-entry lookup via the world registry (Yarn)
  - `>=1.22`: Mojang names + `Holder`
- Mod config screen (Cloth/ModMenu) gains the toggle + four `0.0–1.0` fields.

## Tests

- Plugin: JUnit — `dropChance` branches/clamp; MockBukkit listener with seeded RNG (Looting-II bucket, roll < / > chance, default still drops).
- Mod: gametests — config section round-trips through `ConfigManager`; `dropChance` buckets/clamp; `lootingLevel` reads real Looting II vs plain item (A/B) on every Yarn version.
- Verified: `./gradlew build` (mod, all 1.18.1–1.21.8 + gametests) and `./gradlew -p plugin build` both green.

**Note:** 26.x (Mojang-mapped) only builds on JDK 25, so its branch is verified by CI, not locally.