### PR TITLE
feat(mod): switch config screen to YACL (1.20+), unbundle it — jar 1.2MB→270KB

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ looting3 = 1.0
   above III uses `looting3`. Example: `noLooting = 0.0`, `looting3 = 1.0` drops a head
   only when the killer used a Looting III weapon.
 
-You can also edit these options in-game from the [Mod Menu](https://modrinth.com/mod/modmenu) config screen (Cloth Config is bundled).
+You can also edit these options in-game from the [Mod Menu](https://modrinth.com/mod/modmenu)
+config screen. The screen uses [YACL](https://modrinth.com/mod/yacl) on Minecraft 1.20+ and
+[Cloth Config](https://modrinth.com/mod/cloth-config) on 1.18–1.19 — install the one matching
+your version. Neither is bundled; the mod works fine without a screen (edit the config file).
 
 
 ## Installation

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 
 // Per-version matrix. `fapi` (Fabric API) is used by the main mod and the gametest source set.
 // `cloth` / `modmenu` power the optional in-game config screen.
+// Config screen library differs by version: Cloth Config on <1.20 (YACL has no build there),
+// YACL 3.x on >=1.20. Both are optional (not bundled) — the screen no-ops if absent.
 data class Mc(
     val yarn: String,
     val java: Int,
@@ -19,6 +21,7 @@ data class Mc(
     val fapi: String,
     val cloth: String,
     val modmenu: String,
+    val yacl: String = "",
 )
 
 val mcVersion = stonecutter.current.version
@@ -28,14 +31,14 @@ val mc = when (mcVersion) {
     "1.18.2" -> Mc("1.18.2+build.4", 17, ">=1.18.2 <1.19", listOf("1.18.2"), "0.77.0+1.18.2", "6.5.102", "3.2.5")
     "1.19.2" -> Mc("1.19.2+build.28", 17, ">=1.19 <1.19.3", listOf("1.19", "1.19.1", "1.19.2"), "0.77.0+1.19.2", "8.3.134", "4.1.2")
     "1.19.4" -> Mc("1.19.4+build.2", 17, ">=1.19.3 <1.20", listOf("1.19.3", "1.19.4"), "0.87.2+1.19.4", "10.1.135", "6.3.1")
-    "1.20.1" -> Mc("1.20.1+build.10", 17, ">=1.20 <1.20.2", listOf("1.20", "1.20.1"), "0.92.11+1.20.1", "11.1.136", "7.2.2")
-    "1.20.4" -> Mc("1.20.4+build.3", 17, ">=1.20.2 <1.20.5", listOf("1.20.2", "1.20.3", "1.20.4"), "0.97.3+1.20.4", "13.0.138", "9.2.0")
-    "1.20.6" -> Mc("1.20.6+build.3", 21, ">=1.20.5 <1.21", listOf("1.20.5", "1.20.6"), "0.100.8+1.20.6", "14.0.139", "10.0.0")
+    "1.20.1" -> Mc("1.20.1+build.10", 17, ">=1.20 <1.20.2", listOf("1.20", "1.20.1"), "0.92.11+1.20.1", "11.1.136", "7.2.2", yacl = "3.6.6+1.20.1-fabric")
+    "1.20.4" -> Mc("1.20.4+build.3", 17, ">=1.20.2 <1.20.5", listOf("1.20.2", "1.20.3", "1.20.4"), "0.97.3+1.20.4", "13.0.138", "9.2.0", yacl = "3.6.6+1.20.4-fabric")
+    "1.20.6" -> Mc("1.20.6+build.3", 21, ">=1.20.5 <1.21", listOf("1.20.5", "1.20.6"), "0.100.8+1.20.6", "14.0.139", "10.0.0", yacl = "3.6.6+1.20.6-fabric")
     "1.21.8" -> Mc(
         "1.21.8+build.1", 21, ">=1.21 <1.22",
         // One 1.21.x jar runs on every 1.21.x patch; list them all so Modrinth shows them.
         listOf("1.21", "1.21.1", "1.21.2", "1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11"),
-        "0.136.1+1.21.8", "19.0.147", "15.0.2",
+        "0.136.1+1.21.8", "19.0.147", "15.0.2", yacl = "3.8.2+1.21.6-fabric",
     )
     else -> error("Unconfigured Minecraft version: $mcVersion")
 }
@@ -48,6 +51,7 @@ repositories {
     maven("https://maven.terraformersmc.com/releases/") // ModMenu
     maven("https://maven.shedaniel.me/")                 // Cloth Config
     maven("https://maven.nucleoid.xyz/")                 // placeholder-api (transitive of older ModMenu)
+    maven("https://api.modrinth.com/maven")              // YACL (per-version, via Modrinth)
 }
 
 dependencies {
@@ -57,13 +61,17 @@ dependencies {
     modImplementation("net.fabricmc.fabric-api:fabric-api:${mc.fapi}")
     modImplementation("net.fabricmc:fabric-language-kotlin:${property("fabric_kotlin_version")}")
 
-    // Config screen: ModMenu is optional (a "suggests"), so compile-only. Cloth Config
-    // is bundled (jar-in-jar) so the screen works without the user installing it.
+    // Config screen deps are optional and NOT bundled: ModMenu hosts the screen, and the screen
+    // library is Cloth Config (<1.20) or YACL (>=1.20). Users install whichever their version
+    // needs; the screen no-ops when it is absent (see ModMenuIntegration).
     modImplementation("com.terraformersmc:modmenu:${mc.modmenu}")
-    modImplementation("me.shedaniel.cloth:cloth-config-fabric:${mc.cloth}") {
-        exclude(group = "net.fabricmc.fabric-api")
+    if (mc.yacl.isNotEmpty()) {
+        modImplementation("maven.modrinth:yacl:${mc.yacl}")
+    } else {
+        modImplementation("me.shedaniel.cloth:cloth-config-fabric:${mc.cloth}") {
+            exclude(group = "net.fabricmc.fabric-api")
+        }
     }
-    include("me.shedaniel.cloth:cloth-config-fabric:${mc.cloth}")
 
     // kotlinx-serialization-json is provided at runtime by Fabric Language Kotlin.
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")
@@ -98,6 +106,7 @@ tasks.processResources {
         "version" to project.version,
         "java_level" to mc.java,
         "minecraft_dep" to mc.depends,
+        "config_screen_mod" to if (mc.yacl.isNotEmpty()) "yet_another_config_lib_v3" else "cloth-config",
     )
     inputs.properties(props)
     filesMatching(listOf("fabric.mod.json", "*.mixins.json")) { expand(props) }

--- a/build.unobfuscated.gradle.kts
+++ b/build.unobfuscated.gradle.kts
@@ -9,12 +9,12 @@ plugins {
     kotlin("plugin.serialization") version "2.4.10"
 }
 
-data class Unobf(val depends: String, val gameVersions: List<String>, val fapi: String, val cloth: String, val modmenu: String)
+data class Unobf(val depends: String, val gameVersions: List<String>, val fapi: String, val modmenu: String, val yacl: String)
 
 val mcVersion = stonecutter.current.version
 val u = when (mcVersion) {
-    "26.1.2" -> Unobf(">=26.1 <26.2", listOf("26.1", "26.1.1", "26.1.2"), "0.155.2+26.1.2", "26.1.154", "18.0.0")
-    "26.2" -> Unobf(">=26.2 <27", listOf("26.2"), "0.155.2+26.2", "26.2.155", "20.0.1")
+    "26.1.2" -> Unobf(">=26.1 <26.2", listOf("26.1", "26.1.1", "26.1.2"), "0.155.2+26.1.2", "18.0.0", "3.9.6+26.1-fabric")
+    "26.2" -> Unobf(">=26.2 <27", listOf("26.2"), "0.155.2+26.2", "20.0.1", "3.9.6+26.2-fabric")
     else -> error("Unconfigured Minecraft version: $mcVersion")
 }
 val javaVersion = 25
@@ -25,8 +25,8 @@ base { archivesName = property("archives_base_name") as String }
 
 repositories {
     maven("https://maven.terraformersmc.com/releases/") // ModMenu
-    maven("https://maven.shedaniel.me/")                 // Cloth Config
     maven("https://maven.nucleoid.xyz/")                 // placeholder-api (transitive of older ModMenu)
+    maven("https://api.modrinth.com/maven")              // YACL (per-version, via Modrinth)
 }
 
 dependencies {
@@ -36,12 +36,10 @@ dependencies {
     implementation("net.fabricmc.fabric-api:fabric-api:${u.fapi}")
     implementation("net.fabricmc:fabric-language-kotlin:${property("fabric_kotlin_version")}")
 
-    // Config screen: ModMenu optional (compile-only); Cloth Config bundled (jar-in-jar).
+    // Config screen deps are optional and NOT bundled: ModMenu hosts the screen, YACL renders it.
+    // The screen no-ops when YACL is absent (see ModMenuIntegration).
     implementation("com.terraformersmc:modmenu:${u.modmenu}")
-    implementation("me.shedaniel.cloth:cloth-config-fabric:${u.cloth}") {
-        exclude(group = "net.fabricmc.fabric-api")
-    }
-    include("me.shedaniel.cloth:cloth-config-fabric:${u.cloth}")
+    implementation("maven.modrinth:yacl:${u.yacl}")
 
     // kotlinx-serialization-json is provided at runtime by Fabric Language Kotlin.
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")
@@ -68,6 +66,7 @@ tasks.processResources {
         "version" to project.version,
         "java_level" to javaVersion,
         "minecraft_dep" to u.depends,
+        "config_screen_mod" to "yet_another_config_lib_v3",
     )
     inputs.properties(props)
     filesMatching(listOf("fabric.mod.json", "*.mixins.json")) { expand(props) }

--- a/src/main/kotlin/online/slavok/heads/ModMenuIntegration.kt
+++ b/src/main/kotlin/online/slavok/heads/ModMenuIntegration.kt
@@ -2,7 +2,7 @@ package online.slavok.heads
 
 import com.terraformersmc.modmenu.api.ConfigScreenFactory
 import com.terraformersmc.modmenu.api.ModMenuApi
-import me.shedaniel.clothconfig2.api.ConfigBuilder
+import net.fabricmc.loader.api.FabricLoader
 import online.slavok.heads.config.Config
 import online.slavok.heads.config.PlayerKillLooting
 //? if >=1.22 {
@@ -13,43 +13,30 @@ import net.minecraft.text.Text
 //? if <1.19 {
 /*import net.minecraft.text.LiteralText*/
 //?}
+// Config screen library: Cloth Config on <1.20 (YACL has no build there), YACL 3.x on >=1.20.
+// Both are optional and not bundled — the screen only appears if the user installs the library.
+//? if <1.20 {
+/*import me.shedaniel.clothconfig2.api.ConfigBuilder
+*///?} else {
+import dev.isxander.yacl3.api.ConfigCategory
+import dev.isxander.yacl3.api.Option
+import dev.isxander.yacl3.api.YetAnotherConfigLib
+import dev.isxander.yacl3.api.controller.DoubleFieldControllerBuilder
+import dev.isxander.yacl3.api.controller.TickBoxControllerBuilder
+//?}
 
 /**
- * A tiny Cloth Config screen exposed through ModMenu. ModMenu is optional; when it is
- * absent this entrypoint is simply never called and the config stays file-only.
+ * Exposes the config through ModMenu. ModMenu and the screen library (Cloth Config / YACL) are
+ * all optional: if the screen library is not installed, the factory returns no screen instead of
+ * crashing, and the mod stays fully usable through its config file.
  */
 class ModMenuIntegration : ModMenuApi {
     override fun getModConfigScreenFactory(): ConfigScreenFactory<*> = ConfigScreenFactory { parent ->
         val config = SimplePlayerHeads.configManager.config
-        val builder = ConfigBuilder.create()
-            .setParentScreen(parent)
-            .setTitle(literal("Simple Player Heads"))
-        val category = builder.getOrCreateCategory(literal("General"))
-        val entries = builder.entryBuilder()
 
         var selfKill = config.selfKill
         var playerKill = config.playerKill
         var otherDeaths = config.otherDeaths
-
-        category.addEntry(
-            entries.startBooleanToggle(literal("selfKill"), config.selfKill)
-                .setDefaultValue(true)
-                .setSaveConsumer { selfKill = it }
-                .build(),
-        )
-        category.addEntry(
-            entries.startBooleanToggle(literal("playerKill"), config.playerKill)
-                .setDefaultValue(true)
-                .setSaveConsumer { playerKill = it }
-                .build(),
-        )
-        category.addEntry(
-            entries.startBooleanToggle(literal("otherDeaths"), config.otherDeaths)
-                .setDefaultValue(true)
-                .setSaveConsumer { otherDeaths = it }
-                .build(),
-        )
-
         val looting = config.playerKillLooting
         var lootingEnabled = looting.enabled
         var noLooting = looting.noLooting
@@ -57,47 +44,119 @@ class ModMenuIntegration : ModMenuApi {
         var looting2 = looting.looting2
         var looting3 = looting.looting3
 
+        //? if <1.20 {
+        /*if (!FabricLoader.getInstance().isModLoaded("cloth-config")) return@ConfigScreenFactory null
+        val builder = ConfigBuilder.create()
+            .setParentScreen(parent)
+            .setTitle(literal("Simple Player Heads"))
+        val category = builder.getOrCreateCategory(literal("General"))
+        val entries = builder.entryBuilder()
+
         category.addEntry(
-            entries.startBooleanToggle(literal("playerKillLooting.enabled"), looting.enabled)
-                .setDefaultValue(false)
-                .setSaveConsumer { lootingEnabled = it }
-                .build(),
+            entries.startBooleanToggle(literal("selfKill"), selfKill)
+                .setDefaultValue(true).setSaveConsumer { selfKill = it }.build(),
         )
         category.addEntry(
-            entries.startDoubleField(literal("playerKillLooting.noLooting"), looting.noLooting)
-                .setMin(0.0).setMax(1.0).setDefaultValue(1.0)
-                .setSaveConsumer { noLooting = it }
-                .build(),
+            entries.startBooleanToggle(literal("playerKill"), playerKill)
+                .setDefaultValue(true).setSaveConsumer { playerKill = it }.build(),
         )
         category.addEntry(
-            entries.startDoubleField(literal("playerKillLooting.looting1"), looting.looting1)
-                .setMin(0.0).setMax(1.0).setDefaultValue(1.0)
-                .setSaveConsumer { looting1 = it }
-                .build(),
+            entries.startBooleanToggle(literal("otherDeaths"), otherDeaths)
+                .setDefaultValue(true).setSaveConsumer { otherDeaths = it }.build(),
         )
         category.addEntry(
-            entries.startDoubleField(literal("playerKillLooting.looting2"), looting.looting2)
-                .setMin(0.0).setMax(1.0).setDefaultValue(1.0)
-                .setSaveConsumer { looting2 = it }
-                .build(),
+            entries.startBooleanToggle(literal("playerKillLooting.enabled"), lootingEnabled)
+                .setDefaultValue(false).setSaveConsumer { lootingEnabled = it }.build(),
         )
         category.addEntry(
-            entries.startDoubleField(literal("playerKillLooting.looting3"), looting.looting3)
-                .setMin(0.0).setMax(1.0).setDefaultValue(1.0)
-                .setSaveConsumer { looting3 = it }
-                .build(),
+            entries.startDoubleField(literal("playerKillLooting.noLooting"), noLooting)
+                .setMin(0.0).setMax(1.0).setDefaultValue(0.0).setSaveConsumer { noLooting = it }.build(),
+        )
+        category.addEntry(
+            entries.startDoubleField(literal("playerKillLooting.looting1"), looting1)
+                .setMin(0.0).setMax(1.0).setDefaultValue(0.33).setSaveConsumer { looting1 = it }.build(),
+        )
+        category.addEntry(
+            entries.startDoubleField(literal("playerKillLooting.looting2"), looting2)
+                .setMin(0.0).setMax(1.0).setDefaultValue(0.67).setSaveConsumer { looting2 = it }.build(),
+        )
+        category.addEntry(
+            entries.startDoubleField(literal("playerKillLooting.looting3"), looting3)
+                .setMin(0.0).setMax(1.0).setDefaultValue(1.0).setSaveConsumer { looting3 = it }.build(),
         )
 
         builder.setSavingRunnable {
             SimplePlayerHeads.configManager.save(
-                Config(
-                    selfKill, playerKill, otherDeaths,
-                    PlayerKillLooting(lootingEnabled, noLooting, looting1, looting2, looting3),
-                ),
+                Config(selfKill, playerKill, otherDeaths, PlayerKillLooting(lootingEnabled, noLooting, looting1, looting2, looting3)),
             )
         }
-        builder.build()
+        builder.build()*/
+        //?} else {
+        if (!FabricLoader.getInstance().isModLoaded("yet_another_config_lib_v3")) return@ConfigScreenFactory null
+        val yacl = YetAnotherConfigLib.createBuilder()
+            .title(literal("Simple Player Heads"))
+            .category(
+                ConfigCategory.createBuilder()
+                    .name(literal("General"))
+                    .option(
+                        Option.createBuilder<Boolean>()
+                            .name(literal("selfKill"))
+                            .binding(true, { selfKill }, { selfKill = it })
+                            .controller(TickBoxControllerBuilder::create)
+                            .build(),
+                    )
+                    .option(
+                        Option.createBuilder<Boolean>()
+                            .name(literal("playerKill"))
+                            .binding(true, { playerKill }, { playerKill = it })
+                            .controller(TickBoxControllerBuilder::create)
+                            .build(),
+                    )
+                    .option(
+                        Option.createBuilder<Boolean>()
+                            .name(literal("otherDeaths"))
+                            .binding(true, { otherDeaths }, { otherDeaths = it })
+                            .controller(TickBoxControllerBuilder::create)
+                            .build(),
+                    )
+                    .option(
+                        Option.createBuilder<Boolean>()
+                            .name(literal("playerKillLooting.enabled"))
+                            .binding(false, { lootingEnabled }, { lootingEnabled = it })
+                            .controller(TickBoxControllerBuilder::create)
+                            .build(),
+                    )
+                    .option(chanceOption("playerKillLooting.noLooting", 0.0, { noLooting }, { noLooting = it }))
+                    .option(chanceOption("playerKillLooting.looting1", 0.33, { looting1 }, { looting1 = it }))
+                    .option(chanceOption("playerKillLooting.looting2", 0.67, { looting2 }, { looting2 = it }))
+                    .option(chanceOption("playerKillLooting.looting3", 1.0, { looting3 }, { looting3 = it }))
+                    .build(),
+            )
+            .save {
+                SimplePlayerHeads.configManager.save(
+                    Config(selfKill, playerKill, otherDeaths, PlayerKillLooting(lootingEnabled, noLooting, looting1, looting2, looting3)),
+                )
+            }
+            .build()
+        yacl.generateScreen(parent)
+        //?}
     }
+
+    //? if >=1.20 {
+    /** A 0.0–1.0 drop-chance field option. Supplier/Consumer params so lambda literals at the
+     *  call site convert to YACL's Java binding SAMs. */
+    private fun chanceOption(
+        name: String,
+        default: Double,
+        getter: java.util.function.Supplier<Double>,
+        setter: java.util.function.Consumer<Double>,
+    ): Option<Double> =
+        Option.createBuilder<Double>()
+            .name(literal(name))
+            .binding(default, getter, setter)
+            .controller { DoubleFieldControllerBuilder.create(it).min(0.0).max(1.0) }
+            .build()
+    //?}
 }
 
 //? if >=1.22 {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,10 +37,10 @@
 		"minecraft": "${minecraft_dep}",
 		"java": ">=${java_level}",
 		"fabric-api": "*",
-		"fabric-language-kotlin": "*",
-		"cloth-config": "*"
+		"fabric-language-kotlin": "*"
 	},
 	"suggests": {
-		"modmenu": "*"
+		"modmenu": "*",
+		"${config_screen_mod}": "*"
 	}
 }


### PR DESCRIPTION
Follow-up to #15. Shrinks the Fabric mod jar and makes the in-game config screen optional.

## Why

The jar had grown to ~1.2 MB because **Cloth Config was bundled (jar-in-jar)** and declared a **hard dependency**. The actual mod is a few KB; Cloth was ~1.1 MB of it.

## What

- **Config screen library is no longer bundled** and is now **optional** — removed the `include(...)` and moved it from `depends` to `suggests`. Jar drops to **~270 KB** (only tomlkt remains bundled).
- **YACL on Minecraft 1.20+**, **Cloth Config on 1.18–1.19** (YACL has no build below 1.20). Version-split in `ModMenuIntegration` via Stonecutter; each path guarded by `FabricLoader.isModLoaded(...)` so the screen simply doesn't open when the library is absent — the mod stays fully usable via its config file.
- YACL resolved per Minecraft version via the Modrinth maven (`maven.modrinth:yacl:<ver>`): `3.6.6` (1.20.x), `3.8.2+1.21.6` (1.21.x), `3.9.6` (26.x).
- `fabric.mod.json` `suggests` gets the right library id per version via a `${config_screen_mod}` placeholder.

## Verified

- `./gradlew build` green across the whole Yarn range (1.18.1–1.21.8) + gametests.
- Jar size: **1.28 MB → 270 KB**; nested jars = only `tomlkt`.
- `fabric.mod.json`: `cloth-config` removed from `depends`; `suggests` = `modmenu` + `yet_another_config_lib_v3` (1.20+) / `cloth-config` (1.18–1.19).
- Compiles on 1.21.8 (YACL 3.8.2), 1.20.1 (YACL 3.6.6), 1.18.2 (Cloth).

**Notes:** 26.x (Mojang-mapped) only builds on JDK 25 → verified by CI. The in-game screen rendering wasn't manually run (headless); compilation + dependency resolution pass on all local versions.

The **server plugin is unaffected** — it has no config screen. Its ~1.9 MB is shaded `kotlin-stdlib`, a separate matter.